### PR TITLE
Create indexes for foreign key relations

### DIFF
--- a/migrations/2018-10-15-135520_indexes_for_foreign_keys/down.sql
+++ b/migrations/2018-10-15-135520_indexes_for_foreign_keys/down.sql
@@ -1,0 +1,7 @@
+DROP INDEX entry_category_relations_fk_category_id;
+
+DROP INDEX entry_tag_relations_fk_tag_id;
+
+DROP INDEX comments_fk_rating_id;
+
+DROP INDEX bbox_subscriptions_fk_username;

--- a/migrations/2018-10-15-135520_indexes_for_foreign_keys/up.sql
+++ b/migrations/2018-10-15-135520_indexes_for_foreign_keys/up.sql
@@ -1,0 +1,9 @@
+-- Create missing indexes for foreign key relations
+
+CREATE INDEX entry_category_relations_fk_category_id ON entry_category_relations (category_id);
+
+CREATE INDEX entry_tag_relations_fk_tag_id ON entry_tag_relations (tag_id);
+
+CREATE INDEX comments_fk_rating_id ON comments (rating_id);
+
+CREATE INDEX bbox_subscriptions_fk_username ON bbox_subscriptions (username);


### PR DESCRIPTION
Add the missing indexes that are not already covered by multi-column indexes of primary key or unique constraints.