### PR TITLE
Fix corporate name: "Karte von Morgen" -> "Karte von morgen"

### DIFF
--- a/src/adapters/user_communication.rs
+++ b/src/adapters/user_communication.rs
@@ -3,13 +3,13 @@ use core::usecases::{NewEntry, UpdateEntry};
 
 pub fn email_confirmation_email(u_id: &str) -> String {
     format!(
-        "Na du Weltverbesserer*,\nwir freuen uns dass du bei der Karte von Morgen mit dabei bist!\n\nBitte bestätige deine Email-Adresse hier:\nhttps://kartevonmorgen.org/#/?confirm_email={}.\n\neuphorische Grüße\ndas Karte von Morgen-Team",
+        "Na du Weltverbesserer*,\nwir freuen uns dass du bei der Karte von morgen mit dabei bist!\n\nBitte bestätige deine Email-Adresse hier:\nhttps://kartevonmorgen.org/#/?confirm_email={}.\n\neuphorische Grüße\ndas Karte von morgen-Team",
         u_id
     )
 }
 
 pub fn new_entry_email(e: &NewEntry, id: &str, categories: &[String]) -> String {
-    let intro_sentence = "ein neuer Eintrag auf der Karte von Morgen wurde erstellt";
+    let intro_sentence = "ein neuer Eintrag auf der Karte von morgen wurde erstellt";
     let entry = Entry {
         id: id.into(),
         osm_node: None,
@@ -36,7 +36,7 @@ pub fn new_entry_email(e: &NewEntry, id: &str, categories: &[String]) -> String 
 }
 
 pub fn changed_entry_email(e: &UpdateEntry, categories: &[String]) -> String {
-    let intro_sentence = "folgender Eintrag der Karte von Morgen wurde verändert";
+    let intro_sentence = "folgender Eintrag der Karte von morgen wurde verändert";
     let entry = Entry {
         id: e.id.clone(),
         osm_node: e.osm_node,
@@ -98,7 +98,7 @@ Eintrag anschauen oder bearbeiten:
 https://kartevonmorgen.org/#/?entry={id}\n
 Du kannst dein Abonnement des Kartenbereichs abbestellen indem du dich auf https://kartevonmorgen.org einloggst.\n
 euphorische Grüße
-das Karte von Morgen-Team",
+das Karte von morgen-Team",
         introSentence = intro_sentence,
         title = &e.title,
         id = &e.id,

--- a/src/ports/web/api.rs
+++ b/src/ports/web/api.rs
@@ -190,7 +190,7 @@ fn post_user(mut db: DbConn, u: Json<usecases::NewUser>) -> Result<()> {
     let new_user = u.into_inner();
     usecases::create_new_user(&mut *db, new_user.clone())?;
     let user = db.get_user(&new_user.username)?;
-    let subject = "Karte von Morgen: bitte bestätige deine Email-Adresse";
+    let subject = "Karte von morgen: bitte bestätige deine Email-Adresse";
     let body = user_communication::email_confirmation_email(&user.id);
 
     #[cfg(feature = "email")]

--- a/src/ports/web/util.rs
+++ b/src/ports/web/util.rs
@@ -54,7 +54,7 @@ pub fn notify_create_entry(
     id: &str,
     all_categories: Vec<Category>,
 ) {
-    let subject = String::from("Karte von Morgen - neuer Eintrag: ") + &e.title;
+    let subject = String::from("Karte von morgen - neuer Eintrag: ") + &e.title;
     let categories: Vec<String> = all_categories
         .into_iter()
         .filter(|c| e.categories.clone().into_iter().any(|c_id| *c.id == c_id))
@@ -71,7 +71,7 @@ pub fn notify_update_entry(
     e: &usecases::UpdateEntry,
     all_categories: Vec<Category>,
 ) {
-    let subject = String::from("Karte von Morgen - Eintrag verändert: ") + &e.title;
+    let subject = String::from("Karte von morgen - Eintrag verändert: ") + &e.title;
     let categories: Vec<String> = all_categories
         .into_iter()
         .filter(|c| e.categories.clone().into_iter().any(|c_id| *c.id == c_id))


### PR DESCRIPTION
Fixes the subject of various e-mail notifications. I remembered from our discussions that this is the official naming.

@ziedavid Do we have a GitHub issue for this task?