### PR TITLE
Search tags without specifying hashtag '#' and changes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ written in [Rust](http://rustlang.org/).
 
 ## REST API
 
-The API is available under `http://api.ofdb.io/v0/`. For examples how to use the API, open "network" in the developer tools in your browser and see the requests that [https://kartevonmorgen.org/](https://kartevonmorgen.org/) sends.
+The API is available under `http://api.ofdb.io/v0/`. For examples how to use the API, open "network" in the developer tools in your browser and see the requests that https://kartevonmorgen.org sends.
+
+When you want to use the API, please contact us at helmut@bildungsagenten.com. The API might still change sometimes. We will try to let you know in that case.
 
 -  `GET /entries/:ID_1,:ID_2,...,:ID_n`
 -  `POST /entries`

--- a/src/core/usecases/tests.rs
+++ b/src/core/usecases/tests.rs
@@ -239,7 +239,6 @@ impl Db for MockDb {
         debug!("filtered users: {:?}", users);
         if users.len() > 0 {
             let mut u = users[0].clone();
-            println!("user: {:?}", u);
             u.email_confirmed = true;
             update(&mut self.users, &u)?;
             Ok(u)

--- a/src/core/util/filter.rs
+++ b/src/core/util/filter.rs
@@ -27,7 +27,6 @@ pub fn entries_by_tags_or_search_text<'a>(
 }
 
 fn entries_by_search_text<'a>(text: &'a str) -> impl Fn(&Entry) -> bool + 'a {
-    println!("FILTER BY TEXT");
     let words = to_words(text);
     move |entry| {
         ((!text.is_empty() && words.iter().any(|word| {
@@ -257,7 +256,6 @@ mod tests {
             .cloned()
             .filter(&*entries_by_tags_or_search_text(&tag1, &no_tags))
             .collect();
-        println!("FILTER TEST: {:?}", x);
         assert_eq!(x.len(), 3);
         assert_eq!(x[0].id, "b");
         assert_eq!(x[1].id, "d");

--- a/src/ports/web/tests.rs
+++ b/src/ports/web/tests.rs
@@ -464,8 +464,6 @@ fn search_with_two_hashtags() {
 }
 
 #[test]
-// TODO
-#[ignore]
 fn search_without_specifying_hashtag_symbol() {
     let entries = vec![
         Entry::build().id("a").title("foo").finish(),


### PR DESCRIPTION
- now a search like "organic" finds entries with "organic" either in title, description or tags. "#organic" only finds entries with the tag "#organic".
- README: ask users of the API to contact Helmut


