### PR TITLE
Add a PlantUML class diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ Therefore we use a simple
 [script](https://github.com/slowtec/openfairdb/blob/master/scripts/backup-sqlite.sh)
 that copies the DB file once a day.
 
+# Domain Model
+
+*![The rendered class diagram should appear here!](http://www.plantuml.com/plantuml/svg/RLJ1Yjim4BtxAqIEWLtQQp1XswM7maAXsvx3n1uKiVQCaSRj9gN_NbLZErQK76BhlQStencDduA0bx7lgghf80JpgMqznkUVoiHVu-IyCw_Y7La5U2JnEHR48qe6NTomhF_Erf-F_5vL___Dzk5XRpQ1HpaTVcCGyt5ZdfbzwmW4rnfY7pK8XMPb-ZeUG-FT88x9r3MInBJt-wegoCrsOv9jzFePq9kT2SeVCHXXKvTxjlC6pL_3FeEWPN_EmaqKztt4CcR6eiqI_pk88nipQ9GCPcL10erCJS0UN9ULzyGz3c0n0mKx74vCM5R-MhR9iWFPcHSG9sEBYf2D29DLQDdwXIGxvMpW6gIG9-1wi7WOVNS7xHozPLGCeDRQalHOYXfheg_kWi7KfV87s2WIi0kxj6aktYtymj7JCIq7-tNRf8H4RN556eyWceXAxYUYR9b83XU9NDVpswJzyFWOvTD0tf831vUMTwVYcxT0xg8RYkR1u0x2RqZhRcHRYXFstA87mTKbrVjRkZTCWk_vzy0dxSvyZPH5dx30es-mk13tPqHZrqjixZ157ljby5AcnJXg3wzmELCQEydc7YN_gdf2QiU--mS0)*
+
+Note: Currently the rendered class diagram must be updated manually by uploading the contents of the file [classes.puml](classes.puml) to the [PlantUML Online Editor](http://www.plantuml.com/plantuml/uml/) and replace the link for the rendered diagram with one of the generated URLs.
+
 # License
 
 Copyright (c) 2015 - 2018 Markus Kohlhase

--- a/classes.puml
+++ b/classes.puml
@@ -1,0 +1,84 @@
+@startuml
+
+class Address {
+    city: String
+    country: String
+    street: String
+    zip: String
+}
+
+class Bbox
+
+Bbox *--> "south_west 1" Coordinate
+Bbox *--> "north_east 1" Coordinate
+
+class BboxSubscription <<entity>>
+
+BboxSubscription "*" --> "1" User : subscribes to <
+BboxSubscription *--> "1" Bbox
+
+class Category <<entity>>
+
+class Comment <<entity>>
+
+Comment "1" --> "1" Rating : comments >
+
+class Contact {
+    email: String
+    homepage: String
+    telephone: String
+}
+
+class Coordinate {
+    lat: Latitude
+    lng: Longitude
+}
+
+class Entry <<entity>> {
+    license: String
+    image_url: String
+    image_link_url: String
+}
+
+Entry "*" -- "*" Category : categorizes <
+Entry "*" -- "*" Tag : tags <
+Entry *--> "1" Contact
+Entry *--> "1" Location
+
+class Event <<entity>>
+
+Event "1" --> "1" User : creates <
+Event "*" -- "*" Tag : tags <
+Event *--> "1" Contact
+Event *--> "1" Location
+
+class Location
+
+Location *--> "0..1" Address
+Location *--> "position 1" Coordinate
+
+class Organization <<entity>> {
+    api_token: String
+}
+
+Organization "*" -- "*" Tag : moderates >
+
+class Rating <<entity>> {
+    context: String
+    rating: Integer
+    source: String
+}
+
+Entry "1" --> "1" Rating : rates <
+
+class Role <<enum>>
+
+class Tag <<entity>>
+
+class User <<entity>> {
+    email: String
+}
+
+User *--> "1" Role
+
+@enduml


### PR DESCRIPTION
Disclaimer: The rendered class diagram in the README.md might only be visible on GitHub!

Unfortunately the rendered diagram has to be updated manually after editing the .puml file. Instructions how to do this are included.