### PR TITLE
Improve performance of all_entries()

### DIFF
--- a/src/ports/web/api/tests.rs
+++ b/src/ports/web/api/tests.rs
@@ -151,7 +151,7 @@ fn create_entry_with_sharp_tag() {
     assert_eq!(response.status(), Status::Ok);
     test_json(&response);
     let tags = db.get().unwrap().all_entries().unwrap()[0].tags.clone();
-    assert_eq!(tags, vec!["foo", "bar"]);
+    assert_eq!(tags, vec!["bar", "foo"]);
 }
 
 #[test]


### PR DESCRIPTION
Reduce computational complexity from O(n^ 2) to O(n log n).

This already makes a big difference. The startup in debug mode is now almost as fast as previously in release mode.

I decided to leave the implementation in `util` for converting the `(entry, cat_rels, tag_rels)` tuple as is to avoid unexpected side effects. The unnecessary filtering is acceptable and doesn't hurt.