### PR TITLE
Acquire DB connections lazily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,7 @@ dependencies = [
  "num-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "passwords 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwhash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ num-derive = "*"
 num-traits = "*"
 maud = { version = "*", optional = true, features = ["rocket"] }
 openssl = { version = "*", features = ["vendored"] }
+owning_ref = "*"
 passwords = "*"
 pwhash = "*"
 quick-error = "*"

--- a/src/core/usecases/create_new_user.rs
+++ b/src/core/usecases/create_new_user.rs
@@ -90,8 +90,8 @@ mod tests {
         };
         assert!(create_new_user(&mut db, u).is_ok());
 
-        let (foo_username, _) = get_user(&mut db, "foo", "foo").unwrap();
-        let (baz_username, _) = get_user(&mut db, "baz", "baz").unwrap();
+        let (foo_username, _) = get_user(&db, "foo", "foo").unwrap();
+        let (baz_username, _) = get_user(&db, "baz", "baz").unwrap();
         assert_eq!(foo_username, "foo");
         assert_eq!(baz_username, "baz");
     }

--- a/src/core/usecases/login.rs
+++ b/src/core/usecases/login.rs
@@ -7,7 +7,7 @@ pub struct Login {
     password: String,
 }
 
-pub fn login<D: Db>(db: &mut D, login: &Login) -> Result<String> {
+pub fn login<D: Db>(db: &D, login: &Login) -> Result<String> {
     match db.get_user(&login.username) {
         Ok(u) => {
             if bcrypt::verify(&login.password, &u.password) {

--- a/src/core/usecases/mod.rs
+++ b/src/core/usecases/mod.rs
@@ -133,7 +133,7 @@ pub fn get_entries<D: Db>(db: &D, ids: &[String]) -> Result<Vec<Entry>> {
 }
 
 pub fn get_user<D: Db>(
-    db: &mut D,
+    db: &D,
     logged_in_username: &str,
     requested_username: &str,
 ) -> Result<(String, String)> {

--- a/src/core/usecases/tests.rs
+++ b/src/core/usecases/tests.rs
@@ -409,8 +409,8 @@ mod tests {
                 role: Role::Guest,
             },
         ];
-        assert!(get_user(&mut db, "a", "b").is_err());
-        assert!(get_user(&mut db, "a", "a").is_ok());
+        assert!(get_user(&db, "a", "b").is_err());
+        assert!(get_user(&db, "a", "a").is_ok());
     }
 
     #[test]

--- a/src/ports/web/api/count.rs
+++ b/src/ports/web/api/count.rs
@@ -3,12 +3,12 @@ use super::*;
 #[get("/count/entries")]
 pub fn get_count_entries(db: DbConn) -> Result<usize> {
     // TODO: Replace with count query
-    let entries = db.all_entries()?;
+    let entries = db.pooled()?.all_entries()?;
     Ok(Json(entries.len()))
 }
 
 #[get("/count/tags")]
 pub fn get_count_tags(db: DbConn) -> Result<usize> {
     // TODO: Replace with count query
-    Ok(Json(db.all_tags()?.len()))
+    Ok(Json(db.pooled()?.all_tags()?.len()))
 }

--- a/src/ports/web/api/count.rs
+++ b/src/ports/web/api/count.rs
@@ -3,12 +3,12 @@ use super::*;
 #[get("/count/entries")]
 pub fn get_count_entries(db: DbConn) -> Result<usize> {
     // TODO: Replace with count query
-    let entries = db.pooled()?.all_entries()?;
+    let entries = db.read_only()?.all_entries()?;
     Ok(Json(entries.len()))
 }
 
 #[get("/count/tags")]
 pub fn get_count_tags(db: DbConn) -> Result<usize> {
     // TODO: Replace with count query
-    Ok(Json(db.pooled()?.all_tags()?.len()))
+    Ok(Json(db.read_only()?.all_tags()?.len()))
 }

--- a/src/ports/web/api/events.rs
+++ b/src/ports/web/api/events.rs
@@ -29,7 +29,7 @@ pub fn post_event_with_token(
     let mut e = e.into_inner();
     e.token = Some(token.0);
     check_and_set_address_location(&mut e);
-    let id = usecases::create_new_event(&mut *db.pooled()?, e.clone())?;
+    let id = usecases::create_new_event(&mut *db.read_write()?, e.clone())?;
     Ok(Json(id))
 }
 
@@ -52,7 +52,7 @@ pub fn post_event(mut _db: DbConn, _e: Json<usecases::NewEvent>) -> Status {
 
 #[get("/events/<id>")]
 pub fn get_event(db: DbConn, id: String) -> Result<json::Event> {
-    let mut ev = usecases::get_event(&*db.pooled()?, &id)?;
+    let mut ev = usecases::get_event(&*db.read_only()?, &id)?;
     ev.created_by = None; // don't show creators email to unregistered users
     Ok(Json(ev.into()))
 }
@@ -74,7 +74,7 @@ pub fn put_event_with_token(
     let mut e = e.into_inner();
     e.token = Some(token.0);
     check_and_set_address_location(&mut e);
-    usecases::update_event(&mut *db.pooled()?, &id.to_string(), e.clone())?;
+    usecases::update_event(&mut *db.read_write()?, &id.to_string(), e.clone())?;
     Ok(Json(()))
 }
 
@@ -155,7 +155,7 @@ pub fn get_events_with_token(
 ) -> Result<Vec<json::Event>> {
     //TODO: check token
     let events = usecases::query_events(
-        &*db.pooled()?,
+        &*db.read_only()?,
         query.tags,
         query.bbox,
         query.start_min.map(|x| NaiveDateTime::from_timestamp(x, 0)),
@@ -173,7 +173,7 @@ pub fn get_events(db: DbConn, query: EventQuery) -> Result<Vec<json::Event>> {
         return Err(Error::Parameter(ParameterError::Unauthorized).into());
     }
     let events = usecases::query_events(
-        &*db.pooled()?,
+        &*db.read_only()?,
         query.tags,
         query.bbox,
         query.start_min.map(|x| NaiveDateTime::from_timestamp(x, 0)),
@@ -192,7 +192,7 @@ pub fn delete_event(mut _db: DbConn, _id: &RawStr) -> Status {
 
 #[delete("/events/<id>")]
 pub fn delete_event_with_token(db: DbConn, token: Bearer, id: &RawStr) -> Result<()> {
-    usecases::delete_event(&mut *db.pooled()?, &id.to_string(), &token.0)?;
+    usecases::delete_event(&mut *db.read_write()?, &id.to_string(), &token.0)?;
     Ok(Json(()))
 }
 

--- a/src/ports/web/api/mod.rs
+++ b/src/ports/web/api/mod.rs
@@ -117,7 +117,7 @@ fn get_api() -> Content<&'static str> {
 
 #[post("/login", format = "application/json", data = "<login>")]
 fn login(db: DbConn, mut cookies: Cookies, login: Json<usecases::Login>) -> Result<()> {
-    let username = usecases::login(&mut *db.read_write()?, &login.into_inner())?;
+    let username = usecases::login(&*db.read_only()?, &login.into_inner())?;
     cookies.add_private(
         Cookie::build(COOKIE_USER_KEY, username)
             .same_site(rocket::http::SameSite::None)

--- a/src/ports/web/api/ratings.rs
+++ b/src/ports/web/api/ratings.rs
@@ -4,7 +4,7 @@ use super::*;
 pub fn post_rating(db: DbConn, u: Json<usecases::RateEntry>) -> Result<()> {
     let u = u.into_inner();
     let e_id = u.entry.clone();
-    let mut db = db.pooled()?;
+    let mut db = db.read_write()?;
     usecases::rate_entry(&mut *db, u)?;
     super::super::calculate_rating_for_entry(&*db, &e_id)?;
     Ok(Json(()))
@@ -16,7 +16,7 @@ pub fn get_rating(db: DbConn, ids: String) -> Result<Vec<json::Rating>> {
     // TODO: Add a new method for searching multiple ids
     let mut ids = util::extract_ids(&ids);
     let (ratings, comments) = {
-        let db = db.pooled()?;
+        let db = db.read_only()?;
         let ratings = usecases::get_ratings(&*db, &ids)?;
         // Retain only those ids that have actually been found
         debug_assert!(ratings.len() <= ids.len());

--- a/src/ports/web/api/ratings.rs
+++ b/src/ports/web/api/ratings.rs
@@ -1,9 +1,10 @@
 use super::*;
 
 #[post("/ratings", format = "application/json", data = "<u>")]
-pub fn post_rating(mut db: DbConn, u: Json<usecases::RateEntry>) -> Result<()> {
+pub fn post_rating(db: DbConn, u: Json<usecases::RateEntry>) -> Result<()> {
     let u = u.into_inner();
     let e_id = u.entry.clone();
+    let mut db = db.pooled()?;
     usecases::rate_entry(&mut *db, u)?;
     super::super::calculate_rating_for_entry(&*db, &e_id)?;
     Ok(Json(()))
@@ -14,12 +15,16 @@ pub fn get_rating(db: DbConn, ids: String) -> Result<Vec<json::Rating>> {
     // TODO: Only lookup and return a single entity
     // TODO: Add a new method for searching multiple ids
     let mut ids = util::extract_ids(&ids);
-    let ratings = usecases::get_ratings(&*db, &ids)?;
-    // Retain only those ids that have actually been found
-    debug_assert!(ratings.len() <= ids.len());
-    ids.retain(|id| ratings.iter().any(|r| &r.id == id));
-    debug_assert!(ratings.len() == ids.len());
-    let comments = usecases::get_comments_by_rating_ids(&*db, &ids)?;
+    let (ratings, comments) = {
+        let db = db.pooled()?;
+        let ratings = usecases::get_ratings(&*db, &ids)?;
+        // Retain only those ids that have actually been found
+        debug_assert!(ratings.len() <= ids.len());
+        ids.retain(|id| ratings.iter().any(|r| &r.id == id));
+        debug_assert!(ratings.len() == ids.len());
+        let comments = usecases::get_comments_by_rating_ids(&*db, &ids)?;
+        (ratings, comments)
+    };
     let result = ratings
         .into_iter()
         .map(|x| json::Rating {

--- a/src/ports/web/api/search.rs
+++ b/src/ports/web/api/search.rs
@@ -78,7 +78,7 @@ pub fn get_search(
         entry_ratings: &*avg_ratings,
     };
 
-    let (visible, invisible) = usecases::search(&search_engine, &*db, req, search.limit)?;
+    let (visible, invisible) = usecases::search(&search_engine, &*db.pooled()?, req, search.limit)?;
 
     let visible = visible
         .into_iter()

--- a/src/ports/web/api/search.rs
+++ b/src/ports/web/api/search.rs
@@ -78,7 +78,8 @@ pub fn get_search(
         entry_ratings: &*avg_ratings,
     };
 
-    let (visible, invisible) = usecases::search(&search_engine, &*db.pooled()?, req, search.limit)?;
+    let (visible, invisible) =
+        usecases::search(&search_engine, &*db.read_only()?, req, search.limit)?;
 
     let visible = visible
         .into_iter()

--- a/src/ports/web/api/tests.rs
+++ b/src/ports/web/api/tests.rs
@@ -294,7 +294,7 @@ fn search_with_categories() {
         new_entry_with_category("bar", 3.0),
     ];
     let (client, db, mut search_engine) = setup2();
-    let mut db = db.pooled().unwrap();
+    let mut db = db.read_write().unwrap();
     db.create_category_if_it_does_not_exist(&Category {
         id: "foo".into(),
         created: 0,
@@ -358,7 +358,7 @@ fn search_with_text() {
         new_entry_with_text("baZ", "blub", 3.0),
     ];
     let (client, db, mut search_engine) = setup2();
-    let mut db = db.pooled().unwrap();
+    let mut db = db.read_write().unwrap();
     let entry_ids: Vec<_> = entries
         .into_iter()
         .map(|e| usecases::create_new_entry(&mut *db, Some(&mut search_engine), e).unwrap())
@@ -407,7 +407,7 @@ fn search_with_tags() {
         },
     ];
     let (client, db, mut search_engine) = setup2();
-    let mut db = db.pooled().unwrap();
+    let mut db = db.read_write().unwrap();
     db.create_category_if_it_does_not_exist(&Category {
         id: "foo".into(),
         created: 0,
@@ -463,7 +463,7 @@ fn search_with_uppercase_tags() {
         },
     ];
     let (client, db, mut search_engine) = setup2();
-    let mut db = db.pooled().unwrap();
+    let mut db = db.read_write().unwrap();
     db.create_tag_if_it_does_not_exist(&Tag { id: "foo".into() })
         .unwrap();
     db.create_tag_if_it_does_not_exist(&Tag { id: "bar".into() })
@@ -499,7 +499,7 @@ fn search_with_hashtag() {
         },
     ];
     let (client, db, mut search_engine) = setup2();
-    let mut db = db.pooled().unwrap();
+    let mut db = db.read_write().unwrap();
     db.create_tag_if_it_does_not_exist(&Tag {
         id: "bla-blubb".into(),
     })
@@ -537,7 +537,7 @@ fn search_with_two_hashtags() {
         },
     ];
     let (client, db, mut search_engine) = setup2();
-    let mut db = db.pooled().unwrap();
+    let mut db = db.read_write().unwrap();
     db.create_tag_if_it_does_not_exist(&Tag {
         id: "bla-blubb".into(),
     })
@@ -590,7 +590,7 @@ fn search_with_commata() {
         },
     ];
     let (client, db, mut search_engine) = setup2();
-    let mut db = db.pooled().unwrap();
+    let mut db = db.read_write().unwrap();
     db.create_tag_if_it_does_not_exist(&Tag { id: "eins".into() })
         .unwrap();
     db.create_tag_if_it_does_not_exist(&Tag { id: "zwei".into() })
@@ -640,7 +640,7 @@ fn search_without_specifying_hashtag_symbol() {
         },
     ];
     let (client, db, mut search_engine) = setup2();
-    let mut db = db.pooled().unwrap();
+    let mut db = db.read_write().unwrap();
     db.create_tag_if_it_does_not_exist(&Tag {
         id: "bla-blubb".into(),
     })
@@ -1183,7 +1183,7 @@ fn export_csv() {
     entries[0].homepage = Some("homepage1".to_string());
 
     let (client, db, mut search_engine) = setup2();
-    let mut db = db.pooled().unwrap();
+    let mut db = db.read_write().unwrap();
 
     db.create_category_if_it_does_not_exist(&Category {
         id: "2cd00bebec0c48ba9db761da48678134".into(),

--- a/src/ports/web/api/tests.rs
+++ b/src/ports/web/api/tests.rs
@@ -43,7 +43,7 @@ pub mod prelude {
         let search_engine = tantivy::create_search_engine_in_ram().unwrap();
         let rocket = rocket_instance(pool.clone(), search_engine.clone(), Some(cfg));
         let client = Client::new(rocket).unwrap();
-        (client, sqlite::DbConn(pool.get().unwrap()), search_engine)
+        (client, sqlite::DbConn::new(pool), search_engine)
     }
 
     pub fn test_json(r: &Response) {
@@ -293,7 +293,8 @@ fn search_with_categories() {
         new_entry_with_category("foo", 2.0),
         new_entry_with_category("bar", 3.0),
     ];
-    let (client, mut db, mut search_engine) = setup2();
+    let (client, db, mut search_engine) = setup2();
+    let mut db = db.pooled().unwrap();
     db.create_category_if_it_does_not_exist(&Category {
         id: "foo".into(),
         created: 0,
@@ -356,7 +357,8 @@ fn search_with_text() {
         new_entry_with_text("bar", "foo", 2.0),
         new_entry_with_text("baZ", "blub", 3.0),
     ];
-    let (client, mut db, mut search_engine) = setup2();
+    let (client, db, mut search_engine) = setup2();
+    let mut db = db.pooled().unwrap();
     let entry_ids: Vec<_> = entries
         .into_iter()
         .map(|e| usecases::create_new_entry(&mut *db, Some(&mut search_engine), e).unwrap())
@@ -404,7 +406,8 @@ fn search_with_tags() {
             ..default_new_entry()
         },
     ];
-    let (client, mut db, mut search_engine) = setup2();
+    let (client, db, mut search_engine) = setup2();
+    let mut db = db.pooled().unwrap();
     db.create_category_if_it_does_not_exist(&Category {
         id: "foo".into(),
         created: 0,
@@ -459,7 +462,8 @@ fn search_with_uppercase_tags() {
             ..default_new_entry()
         },
     ];
-    let (client, mut db, mut search_engine) = setup2();
+    let (client, db, mut search_engine) = setup2();
+    let mut db = db.pooled().unwrap();
     db.create_tag_if_it_does_not_exist(&Tag { id: "foo".into() })
         .unwrap();
     db.create_tag_if_it_does_not_exist(&Tag { id: "bar".into() })
@@ -494,7 +498,8 @@ fn search_with_hashtag() {
             ..default_new_entry()
         },
     ];
-    let (client, mut db, mut search_engine) = setup2();
+    let (client, db, mut search_engine) = setup2();
+    let mut db = db.pooled().unwrap();
     db.create_tag_if_it_does_not_exist(&Tag {
         id: "bla-blubb".into(),
     })
@@ -531,7 +536,8 @@ fn search_with_two_hashtags() {
             ..default_new_entry()
         },
     ];
-    let (client, mut db, mut search_engine) = setup2();
+    let (client, db, mut search_engine) = setup2();
+    let mut db = db.pooled().unwrap();
     db.create_tag_if_it_does_not_exist(&Tag {
         id: "bla-blubb".into(),
     })
@@ -583,7 +589,8 @@ fn search_with_commata() {
             ..default_new_entry()
         },
     ];
-    let (client, mut db, mut search_engine) = setup2();
+    let (client, db, mut search_engine) = setup2();
+    let mut db = db.pooled().unwrap();
     db.create_tag_if_it_does_not_exist(&Tag { id: "eins".into() })
         .unwrap();
     db.create_tag_if_it_does_not_exist(&Tag { id: "zwei".into() })
@@ -632,7 +639,8 @@ fn search_without_specifying_hashtag_symbol() {
             ..default_new_entry()
         },
     ];
-    let (client, mut db, mut search_engine) = setup2();
+    let (client, db, mut search_engine) = setup2();
+    let mut db = db.pooled().unwrap();
     db.create_tag_if_it_does_not_exist(&Tag {
         id: "bla-blubb".into(),
     })
@@ -1174,7 +1182,8 @@ fn export_csv() {
     );
     entries[0].homepage = Some("homepage1".to_string());
 
-    let (client, mut db, mut search_engine) = setup2();
+    let (client, db, mut search_engine) = setup2();
+    let mut db = db.pooled().unwrap();
 
     db.create_category_if_it_does_not_exist(&Category {
         id: "2cd00bebec0c48ba9db761da48678134".into(),

--- a/src/ports/web/api/users.rs
+++ b/src/ports/web/api/users.rs
@@ -4,7 +4,7 @@ use super::*;
 pub fn post_user(db: DbConn, u: Json<usecases::NewUser>) -> Result<()> {
     let new_user = u.into_inner();
     let user = {
-        let mut db = db.pooled()?;
+        let mut db = db.read_write()?;
         usecases::create_new_user(&mut *db, new_user.clone())?;
         db.get_user(&new_user.username)?
     };
@@ -19,12 +19,12 @@ pub fn post_user(db: DbConn, u: Json<usecases::NewUser>) -> Result<()> {
 
 #[delete("/users/<u_id>")]
 pub fn delete_user(db: DbConn, user: Login, u_id: String) -> Result<()> {
-    usecases::delete_user(&mut *db.pooled()?, &user.0, &u_id)?;
+    usecases::delete_user(&mut *db.read_write()?, &user.0, &u_id)?;
     Ok(Json(()))
 }
 
 #[get("/users/<username>", format = "application/json")]
 pub fn get_user(db: DbConn, user: Login, username: String) -> Result<json::User> {
-    let (_, email) = usecases::get_user(&mut *db.pooled()?, &user.0, &username)?;
+    let (_, email) = usecases::get_user(&mut *db.read_write()?, &user.0, &username)?;
     Ok(Json(json::User { username, email }))
 }

--- a/src/ports/web/api/users.rs
+++ b/src/ports/web/api/users.rs
@@ -25,6 +25,6 @@ pub fn delete_user(db: DbConn, user: Login, u_id: String) -> Result<()> {
 
 #[get("/users/<username>", format = "application/json")]
 pub fn get_user(db: DbConn, user: Login, username: String) -> Result<json::User> {
-    let (_, email) = usecases::get_user(&mut *db.read_write()?, &user.0, &username)?;
+    let (_, email) = usecases::get_user(&*db.read_only()?, &user.0, &username)?;
     Ok(Json(json::User { username, email }))
 }

--- a/src/ports/web/api/users.rs
+++ b/src/ports/web/api/users.rs
@@ -1,10 +1,13 @@
 use super::*;
 
 #[post("/users", format = "application/json", data = "<u>")]
-pub fn post_user(mut db: DbConn, u: Json<usecases::NewUser>) -> Result<()> {
+pub fn post_user(db: DbConn, u: Json<usecases::NewUser>) -> Result<()> {
     let new_user = u.into_inner();
-    usecases::create_new_user(&mut *db, new_user.clone())?;
-    let user = db.get_user(&new_user.username)?;
+    let user = {
+        let mut db = db.pooled()?;
+        usecases::create_new_user(&mut *db, new_user.clone())?;
+        db.get_user(&new_user.username)?
+    };
     let subject = "Karte von morgen: bitte bestätige deine Email-Adresse";
     let body = user_communication::email_confirmation_email(&user.id);
 
@@ -15,13 +18,13 @@ pub fn post_user(mut db: DbConn, u: Json<usecases::NewUser>) -> Result<()> {
 }
 
 #[delete("/users/<u_id>")]
-pub fn delete_user(mut db: DbConn, user: Login, u_id: String) -> Result<()> {
-    usecases::delete_user(&mut *db, &user.0, &u_id)?;
+pub fn delete_user(db: DbConn, user: Login, u_id: String) -> Result<()> {
+    usecases::delete_user(&mut *db.pooled()?, &user.0, &u_id)?;
     Ok(Json(()))
 }
 
 #[get("/users/<username>", format = "application/json")]
-pub fn get_user(mut db: DbConn, user: Login, username: String) -> Result<json::User> {
-    let (_, email) = usecases::get_user(&mut *db, &user.0, &username)?;
+pub fn get_user(db: DbConn, user: Login, username: String) -> Result<json::User> {
+    let (_, email) = usecases::get_user(&mut *db.pooled()?, &user.0, &username)?;
     Ok(Json(json::User { username, email }))
 }

--- a/src/ports/web/frontend/mod.rs
+++ b/src/ports/web/frontend/mod.rs
@@ -14,14 +14,14 @@ pub fn get_event_js() -> JavaScript<&'static str> {
 
 #[get("/events/<id>")]
 pub fn get_event(db: DbConn, id: String) -> Result<Markup> {
-    let mut ev = usecases::get_event(&*db.pooled()?, &id)?;
+    let mut ev = usecases::get_event(&*db.read_only()?, &id)?;
     ev.created_by = None; // don't show creators email to unregistered users
     Ok(view::event(ev))
 }
 
 #[get("/events")]
 pub fn get_events(db: DbConn) -> Result<Markup> {
-    let events = db.pooled()?.all_events()?;
+    let events = db.read_only()?.all_events()?;
     Ok(view::events(&events))
 }
 

--- a/src/ports/web/frontend/mod.rs
+++ b/src/ports/web/frontend/mod.rs
@@ -14,14 +14,14 @@ pub fn get_event_js() -> JavaScript<&'static str> {
 
 #[get("/events/<id>")]
 pub fn get_event(db: DbConn, id: String) -> Result<Markup> {
-    let mut ev = usecases::get_event(&*db, &id)?;
+    let mut ev = usecases::get_event(&*db.pooled()?, &id)?;
     ev.created_by = None; // don't show creators email to unregistered users
     Ok(view::event(ev))
 }
 
 #[get("/events")]
 pub fn get_events(db: DbConn) -> Result<Markup> {
-    let events = db.all_events()?;
+    let events = db.pooled()?.all_events()?;
     Ok(view::events(&events))
 }
 

--- a/src/ports/web/sqlite.rs
+++ b/src/ports/web/sqlite.rs
@@ -1,32 +1,112 @@
+use crate::core::error::{Error, RepoError};
 use crate::infrastructure::error::AppError;
-use crate::core::error::{RepoError, Error};
-use diesel::r2d2::{ConnectionManager, Pool, self};
+use diesel::r2d2::{self, ConnectionManager, Pool};
 use diesel::sqlite::SqliteConnection;
+use owning_ref::{RwLockReadGuardRef, RwLockWriteGuardRefMut};
 use rocket::request::{self, FromRequest};
 use rocket::{Outcome, Request, State};
+use std::{
+    ops::{Deref, DerefMut},
+    sync::{Arc, RwLock},
+};
 
 embed_migrations!();
 
-static POOL_SIZE: u32 = 5;
+static POOL_SIZE: u32 = 10;
 
 pub type ConnectionPool = Pool<ConnectionManager<SqliteConnection>>;
 pub type PooledConnection = r2d2::PooledConnection<ConnectionManager<SqliteConnection>>;
 
 #[derive(Clone)]
 pub struct DbConn {
-    pool: ConnectionPool,
+    // Only a single connection with write access will be
+    // handed out at a time from the pool. Multiple read
+    // connections can be accessed concurrently. This locking
+    // pattern around the connection pool prevents SQLITE_LOCKED
+    // ("database is locked") errors that are causing internal
+    // server errors and failed requests.
+    pool: Arc<RwLock<ConnectionPool>>,
+}
+
+pub struct DbReadOnly<'a> {
+    _locked_pool: RwLockReadGuardRef<'a, ConnectionPool>,
+    conn: PooledConnection,
+}
+
+impl<'a> DbReadOnly<'a> {
+    fn try_new(pool: &'a Arc<RwLock<ConnectionPool>>) -> Result<Self, Error> {
+        let locked_pool = RwLockReadGuardRef::new(pool.read().unwrap_or_else(|err| {
+            error!("Failed to lock database connection pool for read-only access");
+            err.into_inner()
+        }));
+        let conn = locked_pool.get().map_err(|err| {
+            error!("Failed to obtain pooled database connection for read-only access");
+            Error::Repo(RepoError::Other(Box::new(err)))
+        })?;
+        Ok(Self {
+            _locked_pool: locked_pool,
+            conn,
+        })
+    }
+}
+
+impl<'a> Deref for DbReadOnly<'a> {
+    type Target = SqliteConnection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.conn
+    }
+}
+
+pub struct DbReadWrite<'a> {
+    _locked_pool: RwLockWriteGuardRefMut<'a, ConnectionPool>,
+    conn: PooledConnection,
+}
+
+impl<'a> DbReadWrite<'a> {
+    fn try_new(pool: &'a Arc<RwLock<ConnectionPool>>) -> Result<Self, Error> {
+        let locked_pool = RwLockWriteGuardRefMut::new(pool.write().unwrap_or_else(|err| {
+            error!("Failed to lock database connection pool for read/write access");
+            err.into_inner()
+        }));
+        let conn = locked_pool.get().map_err(|err| {
+            error!("Failed to obtain pooled database connection for read/write access");
+            Error::Repo(RepoError::Other(Box::new(err)))
+        })?;
+        Ok(Self {
+            _locked_pool: locked_pool,
+            conn,
+        })
+    }
+}
+
+impl<'a> Deref for DbReadWrite<'a> {
+    type Target = SqliteConnection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.conn
+    }
+}
+
+impl<'a> DerefMut for DbReadWrite<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.conn
+    }
 }
 
 impl DbConn {
     pub fn new(pool: ConnectionPool) -> Self {
-        Self { pool }
+        Self {
+            pool: Arc::new(RwLock::new(pool)),
+        }
     }
 
-    pub fn pooled(&self) -> Result<PooledConnection, Error> {
-        self.pool.get().map_err(|err| {
-            error!("Failed to obtain pooled database connection");
-            Error::Repo(RepoError::Other(Box::new(err)))
-        }
+    pub fn read_only<'a>(&'a self) -> Result<DbReadOnly<'a>, Error> {
+        DbReadOnly::try_new(&self.pool)
+    }
+
+    pub fn read_write<'a>(&'a self) -> Result<DbReadWrite<'a>, Error> {
+        DbReadWrite::try_new(&self.pool)
     }
 }
 


### PR DESCRIPTION
Defer acquisition of a DB connection until entering the `core` modules.

Further narrowing of the connection scope within `core` would require substantial changes of the repository API.