### PR TITLE
[WiP] Geo types

### DIFF
--- a/src/adapters/csv.rs
+++ b/src/adapters/csv.rs
@@ -38,7 +38,7 @@ impl From<(Entry, Vec<Category>, AvgRatingValue)> for CsvRecord {
             ..
         } = e.clone();
 
-        let Location { lat, lng, address } = location;
+        let Location { pos, address } = location;
 
         let address = address.unwrap_or_default();
 
@@ -62,8 +62,8 @@ impl From<(Entry, Vec<Category>, AvgRatingValue)> for CsvRecord {
             version: version as u64,
             title,
             description,
-            lat,
-            lng,
+            lat: pos.lat().to_deg(),
+            lng: pos.lng().to_deg(),
             street,
             zip,
             city,

--- a/src/adapters/json.rs
+++ b/src/adapters/json.rs
@@ -1,4 +1,4 @@
-use crate::core::{db::IndexedEntry, entities as e};
+use crate::core::{db::IndexedEntry, entities as e, util::geo::MapPoint};
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -138,12 +138,9 @@ pub struct Coordinate {
     pub lng: f64,
 }
 
-impl From<Coordinate> for e::Coordinate {
+impl From<Coordinate> for MapPoint {
     fn from(c: Coordinate) -> Self {
-        e::Coordinate {
-            lat: c.lat,
-            lng: c.lng,
-        }
+        MapPoint::try_from_lat_lng_deg(c.lat, c.lng).unwrap_or_default()
     }
 }
 

--- a/src/adapters/json.rs
+++ b/src/adapters/json.rs
@@ -76,11 +76,17 @@ impl From<e::Event> for Event {
             ..
         } = e;
 
-        let e::Location { lat, lng, address } = location.unwrap_or_default();
-
-        let lat = if lat == 0.0 { None } else { Some(lat) };
-
-        let lng = if lng == 0.0 { None } else { Some(lng) };
+        let (lat, lng, address) = if let Some(location) = location {
+            if location.pos.is_valid() {
+                let lat = location.pos.lat().to_deg();
+                let lng = location.pos.lng().to_deg();
+                (Some(lat), Some(lng), location.address)
+            } else {
+                (None, None, location.address)
+            }
+        } else {
+            (None, None, None)
+        };
 
         let e::Address {
             street,
@@ -245,7 +251,9 @@ impl Entry {
             image_link_url,
             ..
         } = e;
-        let e::Location { lat, lng, address } = location;
+        let e::Location { pos, address } = location;
+        let lat = pos.lat().to_deg();
+        let lng = pos.lng().to_deg();
         let e::Address {
             street,
             zip,

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -61,12 +61,7 @@ pub trait RatingRepository {
 //  - SubscriptionGateway
 
 pub trait Db:
-    EntryGateway
-    + UserGateway
-    + CommentGateway
-    + EventGateway
-    + OrganizationGateway
-    + RatingRepository
+    EntryGateway + UserGateway + CommentGateway + EventGateway + OrganizationGateway + RatingRepository
 {
     fn create_tag_if_it_does_not_exist(&self, _: &Tag) -> Result<()>;
     fn create_category_if_it_does_not_exist(&mut self, _: &Category) -> Result<()>;

--- a/src/core/entities.rs
+++ b/src/core/entities.rs
@@ -353,27 +353,11 @@ pub struct Rating {
     pub source   : Option<String>,
 }
 
-// TODO: Replace by geo::MapPoint
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Coordinate {
-    pub lat: f64,
-    pub lng: f64,
-}
-
-impl From<MapPoint> for Coordinate {
-    fn from(from: MapPoint) -> Self {
-        Self {
-            lat: from.lat().to_deg(),
-            lng: from.lng().to_deg(),
-        }
-    }
-}
-
 // TODO: Replace by geo::MapBbox
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Bbox {
-    pub south_west: Coordinate,
-    pub north_east: Coordinate,
+    pub south_west: MapPoint,
+    pub north_east: MapPoint,
 }
 
 impl From<MapBbox> for Bbox {

--- a/src/core/entities.rs
+++ b/src/core/entities.rs
@@ -24,9 +24,7 @@ pub struct Entry {
 #[cfg_attr(rustfmt, rustfmt_skip)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Location {
-    //TODO: use Coordinate
-    pub lat     : f64,
-    pub lng     : f64,
+    pub pos:      MapPoint,
     pub address : Option<Address>
 }
 
@@ -439,12 +437,8 @@ pub mod entry_builder {
             self.entry.description = desc.into();
             self
         }
-        pub fn lat(mut self, lat: f64) -> Self {
-            self.entry.location.lat = lat;
-            self
-        }
-        pub fn lng(mut self, lng: f64) -> Self {
-            self.entry.location.lng = lng;
+        pub fn pos(mut self, pos: MapPoint) -> Self {
+            self.entry.location.pos = pos;
             self
         }
         pub fn categories(mut self, cats: Vec<&str>) -> Self {
@@ -484,8 +478,7 @@ pub mod entry_builder {
                     title: "".into(),
                     description: "".into(),
                     location: Location {
-                        lat: 0.0,
-                        lng: 0.0,
+                        pos: MapPoint::from_lat_lng_deg(0.0, 0.0),
                         address: None,
                     },
                     contact: None,

--- a/src/core/entities.rs
+++ b/src/core/entities.rs
@@ -353,27 +353,11 @@ pub struct Rating {
     pub source   : Option<String>,
 }
 
-// TODO: Replace by geo::MapBbox
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Bbox {
-    pub south_west: MapPoint,
-    pub north_east: MapPoint,
-}
-
-impl From<MapBbox> for Bbox {
-    fn from(from: MapBbox) -> Bbox {
-        Self {
-            south_west: from.south_west().into(),
-            north_east: from.north_east().into(),
-        }
-    }
-}
-
 #[cfg_attr(rustfmt, rustfmt_skip)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct BboxSubscription {
     pub id       : String,
-    pub bbox     : Bbox,
+    pub bbox     : MapBbox,
     pub username : String,
 }
 

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -67,6 +67,9 @@ quick_error! {
         CreatorEmail{
             description("Missing the email of the creator")
         }
+        InvalidPosition {
+            description("Invalid position")
+        }
         InvalidLimit{
             description("Invalid limit")
         }

--- a/src/core/usecases/create_new_entry.rs
+++ b/src/core/usecases/create_new_entry.rs
@@ -45,6 +45,10 @@ pub fn prepare_new_entry<D: Db>(db: &D, e: NewEntry) -> Result<Storable> {
         tags,
         ..
     } = e;
+    let pos = match MapPoint::try_from_lat_lng_deg(lat, lng) {
+        None => return Err(ParameterError::InvalidPosition.into()),
+        Some(pos) => pos,
+    };
     let tags = super::prepare_tag_list(tags);
     super::check_for_owned_tags(db, &tags, &None)?;
     let address = Address {
@@ -58,7 +62,7 @@ pub fn prepare_new_entry<D: Db>(db: &D, e: NewEntry) -> Result<Storable> {
     } else {
         Some(address)
     };
-    let location = Location { lat, lng, address };
+    let location = Location { pos, address };
     let contact = if email.is_some() || telephone.is_some() {
         Some(Contact { email, telephone })
     } else {

--- a/src/core/usecases/create_new_event.rs
+++ b/src/core/usecases/create_new_event.rs
@@ -121,10 +121,14 @@ pub fn try_into_new_event<D: Db>(db: &mut D, e: NewEvent) -> Result<Event> {
     };
 
     //TODO: use location.is_empty()
-    let location = if lat.is_some() || lng.is_some() || address.is_some() {
+    let pos = if let (Some(lat), Some(lng)) = (lat, lng) {
+        MapPoint::try_from_lat_lng_deg(lat, lng)
+    } else {
+        None
+    };
+    let location = if pos.is_some() || address.is_some() {
         Some(Location {
-            lat: lat.unwrap_or(0.0),
-            lng: lng.unwrap_or(0.0),
+            pos: pos.unwrap_or_default(),
             address,
         })
     } else {

--- a/src/core/usecases/find_duplicates.rs
+++ b/src/core/usecases/find_duplicates.rs
@@ -35,12 +35,8 @@ fn is_duplicate(e1: &Entry, e2: &Entry) -> Option<DuplicateType> {
 }
 
 fn in_close_proximity(e1: &Entry, e2: &Entry, max_dist: Distance) -> bool {
-    let p1 = MapPoint::try_from_lat_lng_deg(e1.location.lat, e1.location.lng);
-    let p2 = MapPoint::try_from_lat_lng_deg(e2.location.lat, e2.location.lng);
-    if let (Some(p1), Some(p2)) = (p1, p2) {
-        if let Some(dist) = MapPoint::distance(&p1, &p2) {
-            return dist <= max_dist;
-        }
+    if let Some(dist) = MapPoint::distance(&e1.location.pos, &e2.location.pos) {
+        return dist <= max_dist;
     }
     false
 }
@@ -156,13 +152,12 @@ fn min3(s: usize, t: usize, u: usize) -> usize {
 mod tests {
     use super::*;
 
-    fn new_entry(title: String, description: String, lat: f64, lng: f64) -> Entry {
+    fn new_entry(title: String, description: String, pos: MapPoint) -> Entry {
         Entry::build()
             .id(&title)
             .title(&title)
             .description(&description)
-            .lat(lat)
-            .lng(lng)
+            .pos(pos)
             .finish()
     }
 
@@ -171,14 +166,12 @@ mod tests {
         let e1 = new_entry(
             "Entry 1".to_string(),
             "Punkt1".to_string(),
-            48.23153745093964,
-            8.003816366195679,
+            MapPoint::from_lat_lng_deg(48.23153745093964, 8.003816366195679),
         );
         let e2 = new_entry(
             "Entry 2".to_string(),
             "Punkt2".to_string(),
-            48.23167056421013,
-            8.003558874130248,
+            MapPoint::from_lat_lng_deg(48.23167056421013, 8.003558874130248),
         );
 
         assert!(in_close_proximity(&e1, &e2, Distance::from_meters(30.0)));
@@ -190,26 +183,22 @@ mod tests {
         let e1 = new_entry(
             "0123456789".to_string(),
             "Hallo! Ein Eintrag".to_string(),
-            48.23153745093964,
-            6.003816366195679,
+            MapPoint::from_lat_lng_deg(48.23153745093964, 6.003816366195679),
         );
         let e2 = new_entry(
             "01234567".to_string(),
             "allo! Ein Eintra".to_string(),
-            48.23153745093964,
-            6.003816366195679,
+            MapPoint::from_lat_lng_deg(48.23153745093964, 6.003816366195679)
         );
         let e3 = new_entry(
             "eins zwei drei".to_string(),
             "allo! Ein Eintra".to_string(),
-            48.23153745093964,
-            6.003816366195679,
+            MapPoint::from_lat_lng_deg(48.23153745093964, 6.003816366195679),
         );
         let e4 = new_entry(
             "eins zwei fünf sechs".to_string(),
             "allo! Ein Eintra".to_string(),
-            48.23153745093964,
-            6.003816366195679,
+            MapPoint::from_lat_lng_deg(48.23153745093964, 6.003816366195679),
         );
 
         assert_eq!(true, similar_title(&e1, &e2, 0.2, 0)); // only 2 characters changed
@@ -223,32 +212,27 @@ mod tests {
         let e1 = new_entry(
             "Ein Eintrag Blablabla".to_string(),
             "Hallo! Ein Eintrag".to_string(),
-            47.23153745093964,
-            5.003816366195679,
+            MapPoint::from_lat_lng_deg(47.23153745093964, 5.003816366195679),
         );
         let e2 = new_entry(
             "Eintrag".to_string(),
             "Hallo! Ein Eintrag".to_string(),
-            47.23153745093970,
-            5.003816366195679,
+            MapPoint::from_lat_lng_deg(47.23153745093970, 5.003816366195679),
         );
         let e3 = new_entry(
             "Enn Eintrxg Blablalx".to_string(),
             "Hallo! Ein Eintrag".to_string(),
-            47.23153745093955,
-            5.003816366195679,
+            MapPoint::from_lat_lng_deg(47.23153745093955, 5.003816366195679),
         );
         let e4 = new_entry(
             "En Eintrg Blablala".to_string(),
             "Hallo! Ein Eintrag".to_string(),
-            47.23153745093955,
-            5.003816366195679,
+            MapPoint::from_lat_lng_deg(47.23153745093955, 5.003816366195679),
         );
         let e5 = new_entry(
             "Ein Eintrag Blabla".to_string(),
             "Hallo! Ein Eintrag".to_string(),
-            40.23153745093960,
-            5.003816366195670,
+            MapPoint::from_lat_lng_deg(40.23153745093960, 5.003816366195670),
         );
 
         // titles have a word that is equal

--- a/src/core/usecases/find_duplicates.rs
+++ b/src/core/usecases/find_duplicates.rs
@@ -188,7 +188,7 @@ mod tests {
         let e2 = new_entry(
             "01234567".to_string(),
             "allo! Ein Eintra".to_string(),
-            MapPoint::from_lat_lng_deg(48.23153745093964, 6.003816366195679)
+            MapPoint::from_lat_lng_deg(48.23153745093964, 6.003816366195679),
         );
         let e3 = new_entry(
             "eins zwei drei".to_string(),

--- a/src/core/usecases/query_events.rs
+++ b/src/core/usecases/query_events.rs
@@ -1,15 +1,16 @@
 use crate::core::{
     prelude::*,
-    util::filter::{self, InBBox},
+    util::{
+        filter::{self, InBBox},
+        geo::MapBbox,
+    },
 };
 use chrono::prelude::*;
-
-use super::map_bbox;
 
 pub fn query_events<D: Db>(
     db: &D,
     tags: Option<Vec<String>>,
-    bbox: Option<Bbox>,
+    bbox: Option<MapBbox>,
     start_min: Option<NaiveDateTime>,
     start_max: Option<NaiveDateTime>,
     created_by: Option<String>,
@@ -27,12 +28,7 @@ pub fn query_events<D: Db>(
 
     let mut events = db.all_events()?;
 
-    if let Some(bbox) = bbox
-        .as_ref()
-        .map(map_bbox)
-        .as_ref()
-        .map(filter::extend_bbox)
-    {
+    if let Some(bbox) = bbox.as_ref().map(filter::extend_bbox) {
         events = events.into_iter().filter(|x| x.in_bbox(&bbox)).collect();
     }
 

--- a/src/core/usecases/query_events.rs
+++ b/src/core/usecases/query_events.rs
@@ -29,7 +29,7 @@ pub fn query_events<D: Db>(
 
     if let Some(bbox) = bbox
         .as_ref()
-        .and_then(map_bbox)
+        .map(map_bbox)
         .as_ref()
         .map(filter::extend_bbox)
     {

--- a/src/core/usecases/tests.rs
+++ b/src/core/usecases/tests.rs
@@ -145,7 +145,7 @@ impl EntryIndex for MockDb {
             ))
             .map(|e| IndexedEntry {
                 id: e.id,
-                pos: MapPoint::from_lat_lng_deg(e.location.lat, e.location.lng),
+                pos: e.location.pos,
                 title: e.title,
                 description: e.description,
                 categories: e.categories,

--- a/src/core/usecases/tests.rs
+++ b/src/core/usecases/tests.rs
@@ -424,14 +424,8 @@ mod tests {
     fn create_bbox_subscription() {
         let mut db = MockDb::default();
         let bbox_new = Bbox {
-            north_east: Coordinate {
-                lat: 10.0,
-                lng: 10.0,
-            },
-            south_west: Coordinate {
-                lat: 10.0,
-                lng: 5.0,
-            },
+            south_west: MapPoint::from_lat_lng_deg(-71.3, 179.5),
+            north_east: MapPoint::from_lat_lng_deg(88.2, -160),
         };
 
         let username = "a";
@@ -453,7 +447,7 @@ mod tests {
         .is_ok());
 
         let bbox_subscription = db.all_bbox_subscriptions().unwrap()[0].clone();
-        assert_eq!(bbox_subscription.bbox.north_east.lat, 10.0);
+        assert_eq!(bbox_subscription.bbox.north_east.lat(), LatCoord::from_deg(88.2));
     }
 
     #[test]
@@ -461,25 +455,13 @@ mod tests {
         let mut db = MockDb::default();
 
         let bbox_old = Bbox {
-            north_east: Coordinate {
-                lat: 50.0,
-                lng: 10.0,
-            },
-            south_west: Coordinate {
-                lat: 50.0,
-                lng: 5.0,
-            },
+            south_west: MapPoint::from_lat_lng_deg(49.0, 5.0),
+            north_east: MapPoint::from_lat_lng_deg(50.0, 10.0),
         };
 
         let bbox_new = Bbox {
-            north_east: Coordinate {
-                lat: 10.0,
-                lng: 10.0,
-            },
-            south_west: Coordinate {
-                lat: 10.0,
-                lng: 5.0,
-            },
+            south_west: MapPoint::from_lat_lng_deg(9.0, 5.0),
+            north_east: MapPoint::from_lat_lng_deg(10.0, 10.0),
         };
 
         let username = "a";
@@ -517,7 +499,7 @@ mod tests {
             .collect();
 
         assert_eq!(bbox_subscriptions.len(), 1);
-        assert_eq!(bbox_subscriptions[0].clone().bbox.north_east.lat, 10.0);
+        assert_eq!(bbox_subscriptions[0].clone().bbox.north_east.lat(), LatCoord::from_deg(10.0));
     }
 
     #[test]
@@ -525,25 +507,13 @@ mod tests {
         let mut db = MockDb::default();
 
         let bbox1 = Bbox {
-            north_east: Coordinate {
-                lat: 50.0,
-                lng: 10.0,
-            },
-            south_west: Coordinate {
-                lat: 50.0,
-                lng: 5.0,
-            },
+            south_west: MapPoint::from_lat_lng_deg(49.0, 5.0),
+            north_east: MapPoint::from_lat_lng_deg(50.0, 10.0),
         };
 
         let bbox2 = Bbox {
-            north_east: Coordinate {
-                lat: 10.0,
-                lng: 10.0,
-            },
-            south_west: Coordinate {
-                lat: 10.0,
-                lng: 5.0,
-            },
+            south_west: MapPoint::from_lat_lng_deg(9.0, 5.0),
+            north_east: MapPoint::from_lat_lng_deg(10.0, 10.0),
         };
 
         let user1 = "a";
@@ -594,11 +564,8 @@ mod tests {
     fn email_addresses_by_coordinate() {
         let mut db = MockDb::default();
         let bbox_new = Bbox {
-            north_east: Coordinate {
-                lat: 10.0,
-                lng: 10.0,
-            },
-            south_west: Coordinate { lat: 0.0, lng: 0.0 },
+            south_west: MapPoint::from_lat_lng_deg(0.0, 0.0),
+            north_east: MapPoint::from_lat_lng_deg(10.0, 10.0),
         };
 
         let username = "a";
@@ -620,11 +587,11 @@ mod tests {
         )
         .unwrap();
 
-        let email_addresses = usecases::email_addresses_by_coordinate(&db, 5.0, 5.0).unwrap();
+        let email_addresses = usecases::email_addresses_by_coordinate(&db, &MapPoint::from_lat_lng_deg(5.0, 5.0)).unwrap();
         assert_eq!(email_addresses.len(), 1);
         assert_eq!(email_addresses[0], "abc@abc.de");
 
-        let no_email_addresses = usecases::email_addresses_by_coordinate(&db, 20.0, 20.0).unwrap();
+        let no_email_addresses = usecases::email_addresses_by_coordinate(&db, &MapPoint::from_lat_lng_deg(20.0, 20.0)).unwrap();
         assert_eq!(no_email_addresses.len(), 0);
     }
 

--- a/src/core/usecases/update_entry.rs
+++ b/src/core/usecases/update_entry.rs
@@ -49,6 +49,10 @@ pub fn prepare_updated_entry<D: Db>(db: &D, id: String, e: UpdateEntry) -> Resul
         tags,
         ..
     } = e;
+    let pos = match MapPoint::try_from_lat_lng_deg(lat, lng) {
+        None => return Err(ParameterError::InvalidPosition.into()),
+        Some(pos) => pos,
+    };
     let tags = super::prepare_tag_list(tags);
     super::check_for_owned_tags(db, &tags, &None)?;
     let address = Address {
@@ -69,7 +73,7 @@ pub fn prepare_updated_entry<D: Db>(db: &D, id: String, e: UpdateEntry) -> Resul
         version,
         title,
         description,
-        location: Location { lat, lng, address },
+        location: Location { pos, address },
         contact: Some(Contact { email, telephone }),
         homepage: e.homepage.map(|ref url| parse_url_param(url)).transpose()?,
         categories,

--- a/src/core/util/filter.rs
+++ b/src/core/util/filter.rs
@@ -48,17 +48,14 @@ pub trait InBBox {
 
 impl InBBox for Entry {
     fn in_bbox(&self, bbox: &MapBbox) -> bool {
-        bbox.contains_point(&MapPoint::from_lat_lng_deg(
-            self.location.lat,
-            self.location.lng,
-        ))
+        bbox.contains_point(&self.location.pos)
     }
 }
 
 impl InBBox for Event {
     fn in_bbox(&self, bbox: &MapBbox) -> bool {
         if let Some(ref location) = self.location {
-            bbox.contains_point(&MapPoint::from_lat_lng_deg(location.lat, location.lng))
+            bbox.contains_point(&location.pos)
         } else {
             false
         }
@@ -138,15 +135,13 @@ mod tests {
         let e = Entry::build()
             .title("foo")
             .description("bar")
-            .lat(5.0)
-            .lng(5.0)
+            .pos(MapPoint::from_lat_lng_deg(5.0, 5.0))
             .finish();
         assert_eq!(e.in_bbox(&bb), true);
         let e = Entry::build()
             .title("foo")
             .description("bar")
-            .lat(10.1)
-            .lng(10.0)
+            .pos(MapPoint::from_lat_lng_deg(10.1, 10.0))
             .finish();
         assert_eq!(e.in_bbox(&bb), false);
     }
@@ -158,9 +153,9 @@ mod tests {
             MapPoint::from_lat_lng_deg(10.0, 10.0),
         );
         let entries = vec![
-            Entry::build().lat(5.0).lng(5.0).finish(),
-            Entry::build().lat(-5.0).lng(5.0).finish(),
-            Entry::build().lat(10.0).lng(10.1).finish(),
+            Entry::build().pos(MapPoint::from_lat_lng_deg(5.0, 5.0)).finish(),
+            Entry::build().pos(MapPoint::from_lat_lng_deg(-5.0, 5.0)).finish(),
+            Entry::build().pos(MapPoint::from_lat_lng_deg(10.0, 10.1)).finish(),
         ];
         assert_eq!(
             entries

--- a/src/core/util/filter.rs
+++ b/src/core/util/filter.rs
@@ -153,9 +153,15 @@ mod tests {
             MapPoint::from_lat_lng_deg(10.0, 10.0),
         );
         let entries = vec![
-            Entry::build().pos(MapPoint::from_lat_lng_deg(5.0, 5.0)).finish(),
-            Entry::build().pos(MapPoint::from_lat_lng_deg(-5.0, 5.0)).finish(),
-            Entry::build().pos(MapPoint::from_lat_lng_deg(10.0, 10.1)).finish(),
+            Entry::build()
+                .pos(MapPoint::from_lat_lng_deg(5.0, 5.0))
+                .finish(),
+            Entry::build()
+                .pos(MapPoint::from_lat_lng_deg(-5.0, 5.0))
+                .finish(),
+            Entry::build()
+                .pos(MapPoint::from_lat_lng_deg(10.0, 10.1))
+                .finish(),
         ];
         assert_eq!(
             entries

--- a/src/core/util/geo.rs
+++ b/src/core/util/geo.rs
@@ -1,7 +1,4 @@
-use super::super::{
-    entities::Bbox,
-    error::ParameterError,
-};
+use super::super::error::ParameterError;
 
 use itertools::Itertools;
 
@@ -450,17 +447,11 @@ impl std::str::FromStr for MapBbox {
     }
 }
 
-// TODO: Replace legacy function
-pub fn extract_bbox(s: &str) -> Result<Bbox, ParameterError> {
-    s.parse::<MapBbox>()
-        .map(|bbox| Bbox {
-            south_west: bbox.south_west(),
-            north_east: bbox.north_east(),
-        })
-        .map_err(|err| {
-            warn!("Failed to parse bounding box: {}", err);
-            ParameterError::Bbox
-        })
+pub fn extract_bbox(s: &str) -> Result<MapBbox, ParameterError> {
+    s.parse::<MapBbox>().map_err(|err| {
+        warn!("Failed to parse bounding box: {}", err);
+        ParameterError::Bbox
+    })
 }
 
 #[cfg(test)]
@@ -683,10 +674,10 @@ mod tests {
         let bb = extract_bbox("0,-10.9876,20,30");
         assert!(bb.is_ok());
         let bb = bb.unwrap();
-        assert_eq!(bb.south_west.lat(), LatCoord::from_deg(0.0));
-        assert_eq!(bb.south_west.lng(), LngCoord::from_deg(-10.9876));
-        assert_eq!(bb.north_east.lat(), LatCoord::from_deg(20.0));
-        assert_eq!(bb.north_east.lng(), LngCoord::from_deg(30.0));
+        assert_eq!(bb.south_west().lat(), LatCoord::from_deg(0.0));
+        assert_eq!(bb.south_west().lng(), LngCoord::from_deg(-10.9876));
+        assert_eq!(bb.north_east().lat(), LatCoord::from_deg(20.0));
+        assert_eq!(bb.north_east().lng(), LngCoord::from_deg(30.0));
     }
 
     #[test]

--- a/src/core/util/geo.rs
+++ b/src/core/util/geo.rs
@@ -1,5 +1,3 @@
-use super::super::error::ParameterError;
-
 use itertools::Itertools;
 
 pub type RawCoord = i32;
@@ -447,13 +445,6 @@ impl std::str::FromStr for MapBbox {
     }
 }
 
-pub fn extract_bbox(s: &str) -> Result<MapBbox, ParameterError> {
-    s.parse::<MapBbox>().map_err(|err| {
-        warn!("Failed to parse bounding box: {}", err);
-        ParameterError::Bbox
-    })
-}
-
 #[cfg(test)]
 mod tests {
 
@@ -666,29 +657,6 @@ mod tests {
         assert!(!bbox2.contains_point(&MapPoint::from_lat_lng_deg(lat4, lng4)));
         assert!(!bbox3.contains_point(&MapPoint::from_lat_lng_deg(lat4, lng4)));
         assert!(bbox4.contains_point(&MapPoint::from_lat_lng_deg(lat4, lng4)));
-    }
-
-    #[test]
-    fn extract_bbox_from_str() {
-        assert!(extract_bbox("0,-10.0870,90,180.0").is_ok());
-        let bb = extract_bbox("0,-10.9876,20,30");
-        assert!(bb.is_ok());
-        let bb = bb.unwrap();
-        assert_eq!(bb.south_west().lat(), LatCoord::from_deg(0.0));
-        assert_eq!(bb.south_west().lng(), LngCoord::from_deg(-10.9876));
-        assert_eq!(bb.north_east().lat(), LatCoord::from_deg(20.0));
-        assert_eq!(bb.north_east().lng(), LngCoord::from_deg(30.0));
-    }
-
-    #[test]
-    fn extract_bbox_from_str_with_missing_lng() {
-        assert!(extract_bbox("5,4,3").is_err());
-    }
-
-    #[test]
-    fn extract_bbox_from_str_with_invalid_chars() {
-        assert!(extract_bbox("5,4,3,o").is_err());
-        assert!(extract_bbox("5;4;3,0").is_err());
     }
 
     use crate::test::Bencher;

--- a/src/core/util/sort.rs
+++ b/src/core/util/sort.rs
@@ -3,14 +3,12 @@ use crate::core::prelude::*;
 use std::cmp::Ordering;
 
 trait DistanceTo {
-    fn distance_to(&self, _there: &MapPoint) -> Distance;
+    fn distance_to(&self, _other: &MapPoint) -> Distance;
 }
 
 impl DistanceTo for Entry {
-    fn distance_to(&self, there: &MapPoint) -> Distance {
-        let here = MapPoint::try_from_lat_lng_deg(self.location.lat, self.location.lng);
-        here.and_then(|ref here| MapPoint::distance(here, there))
-            .unwrap_or(Distance::infinite())
+    fn distance_to(&self, other: &MapPoint) -> Distance {
+        MapPoint::distance(&self.location.pos, other).unwrap_or(Distance::infinite())
     }
 }
 
@@ -57,8 +55,8 @@ pub mod tests {
     use crate::test::Bencher;
     use uuid::Uuid;
 
-    fn new_entry(id: &str, lat: f64, lng: f64) -> Entry {
-        Entry::build().id(id).lat(lat).lng(lng).finish()
+    fn new_entry(id: &str, pos: MapPoint) -> Entry {
+        Entry::build().id(id).pos(pos).finish()
     }
 
     fn new_rating(id: &str, entry_id: &str, value: i8, context: RatingContext) -> Rating {
@@ -75,9 +73,9 @@ pub mod tests {
 
     #[test]
     fn test_average_rating() {
-        let entry1 = new_entry("a", 0.0, 0.0);
-        let entry2 = new_entry("b", 0.0, 0.0);
-        let entry3 = new_entry("c", 0.0, 0.0);
+        let entry1 = new_entry("a", Default::default());
+        let entry2 = new_entry("b", Default::default());
+        let entry3 = new_entry("c", Default::default());
 
         let ratings1 = [
             new_rating("1", "a", -1, RatingContext::Diversity),
@@ -97,8 +95,8 @@ pub mod tests {
 
     #[test]
     fn test_average_rating_different_contexts() {
-        let entry1 = new_entry("a", 0.0, 0.0);
-        let entry2 = new_entry("b", 0.0, 0.0);
+        let entry1 = new_entry("a", Default::default());
+        let entry2 = new_entry("b", Default::default());
 
         let ratings1 = [
             new_rating("1", "a", -1, RatingContext::Diversity),
@@ -121,11 +119,11 @@ pub mod tests {
     #[test]
     fn sort_by_distance() {
         let mut entries = [
-            new_entry("a", 1.0, 0.0),
-            new_entry("b", 0.0, 0.0),
-            new_entry("c", 1.0, 1.0),
-            new_entry("d", 0.0, 0.5),
-            new_entry("e", -1.0, -1.0),
+            new_entry("a", MapPoint::from_lat_lng_deg(1.0, 0.0)),
+            new_entry("b", MapPoint::from_lat_lng_deg(0.0, 0.0)),
+            new_entry("c", MapPoint::from_lat_lng_deg(1.0, 1.0)),
+            new_entry("d", MapPoint::from_lat_lng_deg(0.0, 0.5)),
+            new_entry("e", MapPoint::from_lat_lng_deg(-1.0, -1.0)),
         ];
         let x = MapPoint::from_lat_lng_deg(0.0, 0.0);
         entries.sort_by_distance_to(&x);
@@ -136,33 +134,18 @@ pub mod tests {
         assert!(entries[4].id == "c" || entries[4].id == "e");
     }
 
-    use std::f64::{INFINITY, NAN};
-
     #[test]
     fn sort_with_invalid_coordinates() {
         let mut entries = [
-            new_entry("a", 1.0, NAN),
-            new_entry("b", 1.0, INFINITY),
-            new_entry("c", 2.0, 0.0),
-            new_entry("d", NAN, NAN),
-            new_entry("e", 1.0, 0.0),
+            new_entry("a", Default::default()),
+            new_entry("b", MapPoint::from_lat_lng_deg(1.0, 0.0)),
+            new_entry("c", Default::default()),
+            new_entry("d", MapPoint::from_lat_lng_deg(0.1, 0.2)),
         ];
         let x = MapPoint::from_lat_lng_deg(0.0, 0.0);
         entries.sort_by_distance_to(&x);
-        assert_eq!(entries[0].id, "e");
-        assert_eq!(entries[1].id, "c");
-
-        let mut entries = [
-            new_entry("a", 2.0, 0.0),
-            new_entry("b", 0.0, 0.0),
-            new_entry("c", 1.0, 0.0),
-        ];
-
-        let x = MapPoint::new(LatCoord::default(), LngCoord::from_deg(0.0));
-        entries.sort_by_distance_to(&x);
-        assert_eq!(entries[0].id, "a");
+        assert_eq!(entries[0].id, "d");
         assert_eq!(entries[1].id, "b");
-        assert_eq!(entries[2].id, "c");
     }
 
     pub fn create_entries_with_ratings(n: usize) -> (Vec<Entry>, Vec<Rating>) {

--- a/src/core/util/validate.rs
+++ b/src/core/util/validate.rs
@@ -1,5 +1,5 @@
 use super::super::{
-    entities::*, error::ParameterError, usecases::create_new_user::MAX_USERNAME_LEN,
+    entities::*, error::ParameterError, usecases::create_new_user::MAX_USERNAME_LEN, util::geo::MapPoint,
 };
 use fast_chemail::is_valid_email;
 use regex::Regex;
@@ -107,7 +107,7 @@ impl AutoCorrect for Event {
         self.description = self.description.filter(|x| !x.is_empty());
         self.location = self.location.and_then(|l| {
             let l = l.auto_correct();
-            if l.address.is_none() && l.lat == 0.0 && l.lng == 0.0 {
+            if l.address.is_none() && l.pos == MapPoint::default() {
                 None
             } else {
                 Some(l)
@@ -270,8 +270,7 @@ mod tests {
 
         let mut x = e.clone();
         x.location = Some(Location {
-            lat: 0.0,
-            lng: 0.0,
+            pos: Default::default(),
             address: Some(Address {
                 street: None,
                 zip: None,
@@ -311,8 +310,7 @@ mod tests {
     #[test]
     fn location_autocorrect() {
         let l = Location {
-            lat: 0.0,
-            lng: 0.0,
+            pos: Default::default(),
             address: Some(Address {
                 street: None,
                 zip: Some("".into()),

--- a/src/core/util/validate.rs
+++ b/src/core/util/validate.rs
@@ -1,5 +1,8 @@
 use super::super::{
-    entities::*, error::ParameterError, usecases::create_new_user::MAX_USERNAME_LEN, util::geo::{MapPoint, MapBbox},
+    entities::*,
+    error::ParameterError,
+    usecases::create_new_user::MAX_USERNAME_LEN,
+    util::geo::{MapBbox, MapPoint},
 };
 use fast_chemail::is_valid_email;
 use regex::Regex;
@@ -36,8 +39,7 @@ fn license(s: &str) -> Result<(), ParameterError> {
     }
 }
 
-pub fn bbox(bbox: &Bbox) -> Result<(), ParameterError> {
-    let bbox = MapBbox::new(bbox.south_west, bbox.north_east);
+pub fn bbox(bbox: &MapBbox) -> Result<(), ParameterError> {
     if !bbox.is_valid() || bbox.is_empty() {
         return Err(ParameterError::Bbox);
     }
@@ -372,18 +374,9 @@ mod tests {
         let p1 = MapPoint::from_lat_lng_deg(48.123, 5.123);
         let p2 = MapPoint::try_from_lat_lng_deg(48.123, 500.123).unwrap_or_default();
         let p3 = MapPoint::from_lat_lng_deg(49.123, 10.123);
-        let valid_bbox = Bbox {
-            south_west: p1,
-            north_east: p3,
-        };
-        let empty_bbox = Bbox {
-            south_west: p3,
-            north_east: p3,
-        };
-        let invalid_bbox = Bbox {
-            south_west: p2,
-            north_east: p3,
-        };
+        let valid_bbox = MapBbox::new(p1, p3);
+        let empty_bbox = MapBbox::new(p3, p3);
+        let invalid_bbox = MapBbox::new(p2, p3);
         assert!(bbox(&valid_bbox).is_ok());
         assert!(bbox(&empty_bbox).is_err());
         assert!(bbox(&invalid_bbox).is_err());

--- a/src/infrastructure/db/sqlite/util.rs
+++ b/src/infrastructure/db/sqlite/util.rs
@@ -1,8 +1,8 @@
 use super::models::*;
 use crate::core::{
     entities as e,
-    util::geo::MapPoint,
     prelude::{Error, ParameterError, Result},
+    util::geo::{MapBbox, MapPoint},
 };
 use chrono::prelude::*;
 use std::str::FromStr;
@@ -514,10 +514,10 @@ impl From<BboxSubscription> for e::BboxSubscription {
         } = s;
         e::BboxSubscription {
             id,
-            bbox: e::Bbox {
-                south_west: MapPoint::try_from_lat_lng_deg(south_west_lat, south_west_lng).unwrap_or_default(),
-                north_east: MapPoint::try_from_lat_lng_deg(north_east_lat, north_east_lng).unwrap_or_default(),
-            },
+            bbox: MapBbox::new(
+                MapPoint::try_from_lat_lng_deg(south_west_lat, south_west_lng).unwrap_or_default(),
+                MapPoint::try_from_lat_lng_deg(north_east_lat, north_east_lng).unwrap_or_default(),
+            ),
             username,
         }
     }
@@ -528,10 +528,10 @@ impl From<e::BboxSubscription> for BboxSubscription {
         let e::BboxSubscription { id, bbox, username } = s;
         BboxSubscription {
             id,
-            south_west_lat: bbox.south_west.lat().to_deg(),
-            south_west_lng: bbox.south_west.lng().to_deg(),
-            north_east_lat: bbox.north_east.lat().to_deg(),
-            north_east_lng: bbox.north_east.lng().to_deg(),
+            south_west_lat: bbox.south_west().lat().to_deg(),
+            south_west_lng: bbox.south_west().lng().to_deg(),
+            north_east_lat: bbox.north_east().lat().to_deg(),
+            north_east_lng: bbox.north_east().lng().to_deg(),
             username,
         }
     }

--- a/src/infrastructure/db/sqlite/util.rs
+++ b/src/infrastructure/db/sqlite/util.rs
@@ -515,14 +515,8 @@ impl From<BboxSubscription> for e::BboxSubscription {
         e::BboxSubscription {
             id,
             bbox: e::Bbox {
-                south_west: e::Coordinate {
-                    lat: south_west_lat as f64,
-                    lng: south_west_lng as f64,
-                },
-                north_east: e::Coordinate {
-                    lat: north_east_lat as f64,
-                    lng: north_east_lng as f64,
-                },
+                south_west: MapPoint::try_from_lat_lng_deg(south_west_lat, south_west_lng).unwrap_or_default(),
+                north_east: MapPoint::try_from_lat_lng_deg(north_east_lat, north_east_lng).unwrap_or_default(),
             },
             username,
         }
@@ -534,10 +528,10 @@ impl From<e::BboxSubscription> for BboxSubscription {
         let e::BboxSubscription { id, bbox, username } = s;
         BboxSubscription {
             id,
-            south_west_lat: bbox.south_west.lat,
-            south_west_lng: bbox.south_west.lng,
-            north_east_lat: bbox.north_east.lat,
-            north_east_lng: bbox.north_east.lng,
+            south_west_lat: bbox.south_west.lat().to_deg(),
+            south_west_lng: bbox.south_west.lng().to_deg(),
+            north_east_lat: bbox.north_east.lat().to_deg(),
+            north_east_lng: bbox.north_east.lng().to_deg(),
             username,
         }
     }

--- a/src/infrastructure/db/tantivy/mod.rs
+++ b/src/infrastructure/db/tantivy/mod.rs
@@ -390,11 +390,11 @@ impl EntryIndexer for TantivyEntryIndex {
         doc.add_text(self.fields.id, &entry.id);
         doc.add_i64(
             self.fields.lat,
-            i64::from(LatCoord::from_deg(entry.location.lat).to_raw()),
+            i64::from(entry.location.pos.lat().to_raw()),
         );
         doc.add_i64(
             self.fields.lng,
-            i64::from(LngCoord::from_deg(entry.location.lng).to_raw()),
+            i64::from(entry.location.pos.lng().to_raw()),
         );
         doc.add_text(self.fields.title, &entry.title);
         doc.add_text(self.fields.description, &entry.description);

--- a/src/infrastructure/flows/add_entry.rs
+++ b/src/infrastructure/flows/add_entry.rs
@@ -61,8 +61,7 @@ fn notify_entry_added(connections: &sqlite::Connections, entry: &Entry) -> Resul
         let connection = connections.shared()?;
         let email_addresses = usecases::email_addresses_by_coordinate(
             &*connection,
-            entry.location.pos.lat().to_deg(),
-            entry.location.pos.lng().to_deg(),
+            &entry.location.pos,
         )?;
         let all_categories = connection.all_categories()?;
         (email_addresses, all_categories)

--- a/src/infrastructure/flows/add_entry.rs
+++ b/src/infrastructure/flows/add_entry.rs
@@ -17,8 +17,8 @@ pub fn add_entry(
             .transaction::<_, diesel::result::Error, _>(|| {
                 match usecases::prepare_new_entry(&*connection, new_entry) {
                     Ok(storable) => {
-                        let (entry, ratings) =
-                            usecases::store_new_entry(&*connection, storable).map_err(|err| {
+                        let (entry, ratings) = usecases::store_new_entry(&*connection, storable)
+                            .map_err(|err| {
                                 warn!("Failed to store newly created entry: {}", err);
                                 diesel::result::Error::RollbackTransaction
                             })?;
@@ -36,7 +36,7 @@ pub fn add_entry(
                 } else {
                     RepoError::from(err).into()
                 }
-            }
+            })
     }?;
 
     // Index newly added entry
@@ -59,10 +59,8 @@ pub fn add_entry(
 fn notify_entry_added(connections: &sqlite::Connections, entry: &Entry) -> Result<()> {
     let (email_addresses, all_categories) = {
         let connection = connections.shared()?;
-        let email_addresses = usecases::email_addresses_by_coordinate(
-            &*connection,
-            &entry.location.pos,
-        )?;
+        let email_addresses =
+            usecases::email_addresses_by_coordinate(&*connection, &entry.location.pos)?;
         let all_categories = connection.all_categories()?;
         (email_addresses, all_categories)
     };

--- a/src/infrastructure/flows/add_entry.rs
+++ b/src/infrastructure/flows/add_entry.rs
@@ -61,8 +61,8 @@ fn notify_entry_added(connections: &sqlite::Connections, entry: &Entry) -> Resul
         let connection = connections.shared()?;
         let email_addresses = usecases::email_addresses_by_coordinate(
             &*connection,
-            entry.location.lat,
-            entry.location.lng,
+            entry.location.pos.lat().to_deg(),
+            entry.location.pos.lng().to_deg(),
         )?;
         let all_categories = connection.all_categories()?;
         (email_addresses, all_categories)

--- a/src/infrastructure/flows/add_rating.rs
+++ b/src/infrastructure/flows/add_rating.rs
@@ -15,11 +15,11 @@ pub fn add_rating(
             .transaction::<_, diesel::result::Error, _>(|| {
                 match usecases::prepare_new_rating(&*connection, rate_entry) {
                     Ok(storable) => {
-                        let (entry, ratings) =
-                            usecases::store_new_rating(&*connection, storable).map_err(|err| {
-                                warn!("Failed to store new rating for entry: {}", err);
-                                diesel::result::Error::RollbackTransaction
-                            })?;
+                        let (entry, ratings) = usecases::store_new_rating(&*connection, storable)
+                            .map_err(|err| {
+                            warn!("Failed to store new rating for entry: {}", err);
+                            diesel::result::Error::RollbackTransaction
+                        })?;
                         Ok((entry, ratings))
                     }
                     Err(err) => {

--- a/src/infrastructure/flows/update_entry.rs
+++ b/src/infrastructure/flows/update_entry.rs
@@ -60,8 +60,7 @@ fn notify_entry_updated(connections: &sqlite::Connections, entry: &Entry) -> Res
         let connection = connections.shared()?;
         let email_addresses = usecases::email_addresses_by_coordinate(
             &*connection,
-            entry.location.pos.lat().to_deg(),
-            entry.location.pos.lng().to_deg(),
+            &entry.location.pos,
         )?;
         let all_categories = connection.all_categories()?;
         (email_addresses, all_categories)

--- a/src/infrastructure/flows/update_entry.rs
+++ b/src/infrastructure/flows/update_entry.rs
@@ -16,11 +16,13 @@ pub fn update_entry(
             .transaction::<_, diesel::result::Error, _>(|| {
                 match usecases::prepare_updated_entry(&*connection, id, update_entry) {
                     Ok(storable) => {
-                        let (entry, ratings) = usecases::store_updated_entry(&*connection, storable)
-                            .map_err(|err| {
-                                warn!("Failed to store updated entry: {}", err);
-                                diesel::result::Error::RollbackTransaction
-                            })?;
+                        let (entry, ratings) =
+                            usecases::store_updated_entry(&*connection, storable).map_err(
+                                |err| {
+                                    warn!("Failed to store updated entry: {}", err);
+                                    diesel::result::Error::RollbackTransaction
+                                },
+                            )?;
                         Ok((entry, ratings))
                     }
                     Err(err) => {
@@ -58,10 +60,8 @@ pub fn update_entry(
 fn notify_entry_updated(connections: &sqlite::Connections, entry: &Entry) -> Result<()> {
     let (email_addresses, all_categories) = {
         let connection = connections.shared()?;
-        let email_addresses = usecases::email_addresses_by_coordinate(
-            &*connection,
-            &entry.location.pos,
-        )?;
+        let email_addresses =
+            usecases::email_addresses_by_coordinate(&*connection, &entry.location.pos)?;
         let all_categories = connection.all_categories()?;
         (email_addresses, all_categories)
     };

--- a/src/infrastructure/flows/update_entry.rs
+++ b/src/infrastructure/flows/update_entry.rs
@@ -60,8 +60,8 @@ fn notify_entry_updated(connections: &sqlite::Connections, entry: &Entry) -> Res
         let connection = connections.shared()?;
         let email_addresses = usecases::email_addresses_by_coordinate(
             &*connection,
-            entry.location.lat,
-            entry.location.lng,
+            entry.location.pos.lat().to_deg(),
+            entry.location.pos.lng().to_deg(),
         )?;
         let all_categories = connection.all_categories()?;
         (email_addresses, all_categories)

--- a/src/infrastructure/osm.rs
+++ b/src/infrastructure/osm.rs
@@ -109,8 +109,7 @@ fn map_osm_to_ofdb_entry(osm: &OsmEntry) -> Result<Entry> {
 
     let osm_node = Some(osm.id);
 
-    let lat = osm.lat;
-    let lng = osm.lon;
+    let pos = MapPoint::try_from_lat_lng_deg(osm.lat, osm.lon).unwrap_or_default();
 
     let version = 0;
     let created = Utc::now().timestamp() as u64;
@@ -146,7 +145,7 @@ fn map_osm_to_ofdb_entry(osm: &OsmEntry) -> Result<Entry> {
         country,
     });
 
-    let location = Location { lat, lng, address };
+    let location = Location { pos, address };
 
     Ok(Entry {
         id,
@@ -243,8 +242,8 @@ fn test_from_osm_for_entry() {
 
     let e = map_osm_to_ofdb_entry(&osm).unwrap();
 
-    assert_eq!(e.location.lat, 48.0);
-    assert_eq!(e.location.lng, 10.0);
+    assert_eq!(e.location.pos.lat(), LatCoord::from_deg(48.0));
+    assert_eq!(e.location.pos.lng(), LngCoord::from_deg(10.0));
     assert_eq!(e.version, 0);
     assert_eq!(e.osm_node, Some(12123));
     assert_eq!(e.title, "denn's Biomarkt");

--- a/src/ports/cli.rs
+++ b/src/ports/cli.rs
@@ -21,12 +21,14 @@ fn update_event_locations<D: Db>(db: &mut D) -> Result<()> {
         if let Some(ref mut loc) = e.location {
             if let Some(ref addr) = loc.address {
                 if let Some((lat, lng)) = web::api::geocoding::resolve_address_lat_lng(addr) {
-                    loc.lat = lat;
-                    loc.lng = lng;
-                    if let Err(err) = db.update_event(&e) {
-                        warn!("Failed to update location of event {}: {}", e.id, err);
-                    } else {
-                        info!("Updated location of event {}", e.id);
+                    if let Some(pos) = MapPoint::try_from_lat_lng_deg(lat, lng) {
+                        if pos.is_valid() {
+                            if let Err(err) = db.update_event(&e) {
+                                warn!("Failed to update location of event {}: {}", e.id, err);
+                            } else {
+                                info!("Updated location of event {}", e.id);
+                            }
+                        }
                     }
                 }
             }

--- a/src/ports/web/api/events.rs
+++ b/src/ports/web/api/events.rs
@@ -1,5 +1,7 @@
 use super::{super::guards::Bearer, geocoding::*, *};
 
+use crate::core::util::{geo::MapBbox, validate};
+
 use chrono::prelude::*;
 use rocket::{
     http::{RawStr, Status},
@@ -86,7 +88,7 @@ pub fn put_event_with_token(
 pub struct EventQuery {
     tags: Option<Vec<String>>,
     created_by: Option<String>,
-    bbox: Option<Bbox>,
+    bbox: Option<MapBbox>,
     start_min: Option<i64>,
     start_max: Option<i64>,
 }
@@ -143,7 +145,10 @@ impl<'q> FromQuery<'q> for EventQuery {
             .filter(|v| !v.is_empty())
             .nth(0);
         if let Some(bbox) = bbox {
-            let bbox = geo::extract_bbox(&bbox)?;
+            let bbox = bbox
+                .parse::<MapBbox>()
+                .map_err(|_err| ParameterError::Bbox)?;
+            validate::bbox(&bbox)?;
             q.bbox = Some(bbox);
         }
 

--- a/src/ports/web/api/events.rs
+++ b/src/ports/web/api/events.rs
@@ -858,8 +858,7 @@ mod tests {
                         start: NaiveDateTime::from_timestamp(0, 0),
                         end: None,
                         location: Some(Location {
-                            lat,
-                            lng,
+                            pos: MapPoint::from_lat_lng_deg(lat, lng),
                             address: None,
                         }),
                         contact: None,

--- a/src/ports/web/api/mod.rs
+++ b/src/ports/web/api/mod.rs
@@ -158,8 +158,12 @@ fn subscribe_to_bbox(
         .into_iter()
         .map(MapPoint::from)
         .collect();
+    if sw_ne.len() != 2 {
+        return Err(Error::Parameter(ParameterError::Bbox).into());
+    }
+    let bbox = geo::MapBbox::new(sw_ne[0], sw_ne[1]);
     let Login(username) = user;
-    usecases::subscribe_to_bbox(&sw_ne, &username, &mut *db.exclusive()?)?;
+    usecases::subscribe_to_bbox(bbox, &username, &mut *db.exclusive()?)?;
     Ok(Json(()))
 }
 
@@ -180,10 +184,10 @@ fn get_bbox_subscriptions(
         .into_iter()
         .map(|s| json::BboxSubscription {
             id: s.id,
-            south_west_lat: s.bbox.south_west.lat().to_deg(),
-            south_west_lng: s.bbox.south_west.lng().to_deg(),
-            north_east_lat: s.bbox.north_east.lat().to_deg(),
-            north_east_lng: s.bbox.north_east.lng().to_deg(),
+            south_west_lat: s.bbox.south_west().lat().to_deg(),
+            south_west_lng: s.bbox.south_west().lng().to_deg(),
+            north_east_lat: s.bbox.north_east().lat().to_deg(),
+            north_east_lng: s.bbox.north_east().lng().to_deg(),
         })
         .collect();
     Ok(Json(user_subscriptions))

--- a/src/ports/web/api/mod.rs
+++ b/src/ports/web/api/mod.rs
@@ -153,13 +153,13 @@ fn subscribe_to_bbox(
     user: Login,
     coordinates: Json<Vec<json::Coordinate>>,
 ) -> Result<()> {
-    let coordinates: Vec<Coordinate> = coordinates
+    let sw_ne: Vec<_> = coordinates
         .into_inner()
         .into_iter()
-        .map(Coordinate::from)
+        .map(MapPoint::from)
         .collect();
     let Login(username) = user;
-    usecases::subscribe_to_bbox(&coordinates, &username, &mut *db.exclusive()?)?;
+    usecases::subscribe_to_bbox(&sw_ne, &username, &mut *db.exclusive()?)?;
     Ok(Json(()))
 }
 
@@ -180,10 +180,10 @@ fn get_bbox_subscriptions(
         .into_iter()
         .map(|s| json::BboxSubscription {
             id: s.id,
-            south_west_lat: s.bbox.south_west.lat,
-            south_west_lng: s.bbox.south_west.lng,
-            north_east_lat: s.bbox.north_east.lat,
-            north_east_lng: s.bbox.north_east.lng,
+            south_west_lat: s.bbox.south_west.lat().to_deg(),
+            south_west_lng: s.bbox.south_west.lng().to_deg(),
+            north_east_lat: s.bbox.north_east.lat().to_deg(),
+            north_east_lng: s.bbox.north_east.lng().to_deg(),
         })
         .collect();
     Ok(Json(user_subscriptions))

--- a/src/ports/web/api/tests.rs
+++ b/src/ports/web/api/tests.rs
@@ -1194,8 +1194,7 @@ fn export_csv() {
             .version(3)
             .title("title1")
             .description("desc1")
-            .lat(0.1)
-            .lng(0.2)
+            .pos(MapPoint::from_lat_lng_deg(0.1, 0.2))
             .categories(vec![
                 "2cd00bebec0c48ba9db761da48678134",
                 "77b3c33a92554bcf8e8c2c86cedd6f6f",
@@ -1206,14 +1205,11 @@ fn export_csv() {
         Entry::build()
             .id("entry2")
             .categories(vec!["2cd00bebec0c48ba9db761da48678134"])
-            .lat(0.0)
-            .lng(0.0)
             .finish(),
         Entry::build()
             .id("entry3")
             .categories(vec!["77b3c33a92554bcf8e8c2c86cedd6f6f"])
-            .lat(2.0)
-            .lng(2.0)
+            .pos(MapPoint::from_lat_lng_deg(2.0, 2.0))
             .finish(),
     ];
     entries[0].location.address = Some(Address::build().street("street1").finish());
@@ -1309,7 +1305,7 @@ fn export_csv() {
         }
     }
     let body_str = response.body().and_then(|b| b.into_string()).unwrap();
-    assert_eq!(body_str, "id,osm_node,created,version,title,description,lat,lng,street,zip,city,country,homepage,categories,tags,license,avg_rating\n\
-        entry1,1,2,3,title1,desc1,0.1,0.2,street1,zip1,city1,country1,homepage1,\"cat1,cat2\",\"bla,bli\",license1,0.25\n\
-        entry2,,0,0,,,0,0,,,,,,cat1,,,0\n");
+    assert_eq!(body_str, format!("id,osm_node,created,version,title,description,lat,lng,street,zip,city,country,homepage,categories,tags,license,avg_rating\n\
+        entry1,1,2,3,title1,desc1,{lat1},{lng1},street1,zip1,city1,country1,homepage1,\"cat1,cat2\",\"bla,bli\",license1,0.25\n\
+        entry2,,0,0,,,0,0,,,,,,cat1,,,0\n", lat1 = LatCoord::from_deg(0.1).to_deg(), lng1 = LngCoord::from_deg(0.2).to_deg()));
 }

--- a/src/ports/web/api/tests.rs
+++ b/src/ports/web/api/tests.rs
@@ -235,7 +235,12 @@ fn get_one_entry() {
     let body_str = response.body().and_then(|b| b.into_string()).unwrap();
     assert_eq!(body_str.as_str().chars().nth(0).unwrap(), '[');
     let entries: Vec<json::Entry> = serde_json::from_str(&body_str).unwrap();
-    let rating = connections.shared().unwrap().all_ratings_for_entry_by_id("get_one_entry_test").unwrap()[0].clone();
+    let rating = connections
+        .shared()
+        .unwrap()
+        .all_ratings_for_entry_by_id("get_one_entry_test")
+        .unwrap()[0]
+        .clone();
     assert!(body_str.contains(&format!(r#""ratings":["{}"]"#, rating.id)));
     assert_eq!(
         entries[0],
@@ -819,7 +824,12 @@ fn create_rating() {
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(
-        connections.shared().unwrap().all_ratings_for_entry_by_id("foo").unwrap()[0].value,
+        connections
+            .shared()
+            .unwrap()
+            .all_ratings_for_entry_by_id("foo")
+            .unwrap()[0]
+            .value,
         RatingValue::from(1)
     );
     test_json(&response);
@@ -844,7 +854,11 @@ fn get_one_rating() {
         },
     )
     .unwrap();
-    let rid = connections.shared().unwrap().all_ratings_for_entry_by_id("foo").unwrap()[0]
+    let rid = connections
+        .shared()
+        .unwrap()
+        .all_ratings_for_entry_by_id("foo")
+        .unwrap()[0]
         .id
         .clone();
     let req = client.get(format!("/ratings/{}", rid));
@@ -894,7 +908,11 @@ fn ratings_with_and_without_source() {
     )
     .unwrap();
 
-    let rid = connections.shared().unwrap().all_ratings_for_entry_by_id("bar").unwrap()[0]
+    let rid = connections
+        .shared()
+        .unwrap()
+        .all_ratings_for_entry_by_id("bar")
+        .unwrap()[0]
         .id
         .clone();
     let req = client.get(format!("/ratings/{}", rid));

--- a/src/ports/web/frontend/view.rs
+++ b/src/ports/web/frontend/view.rs
@@ -49,7 +49,7 @@ pub fn event(ev: Event) -> Markup {
                     }
                     h4 {"Koordinaten"}
                     p{
-                        (format!("{:.2} / {:.2}",location.lat, location.lng))
+                        (format!("{:.2} / {:.2}",location.pos.lat().to_deg(), location.pos.lng().to_deg()))
                     }
             }
             @if let Some(org) = ev.organizer {
@@ -100,7 +100,7 @@ pub fn event(ev: Event) -> Markup {
                     integrity=(LEAFLET_JS_SHA512)
                     crossorigin=""{}
                 script{
-                    (format!("window.OFDB_EVENT_POS={{lat:{lat},lng:{lng}}};", lat=location.lat,lng=location.lng))
+                    (format!("window.OFDB_EVENT_POS={{lat:{lat},lng:{lng}}};", lat=location.pos.lat().to_deg(),lng=location.pos.lng().to_deg()))
                 }
                 script src= "/frontend/event.js"{}
             }


### PR DESCRIPTION
* Replace individual lat/lng properties with the type-safe `geo::MapPoint` wrapper
* Replace `Bbox` with `geo::MapBbox`
* Only internal changes, i.e. the public **API has not changed**!

The `Map` prefix might be removed from the `geo` types after the ambiguous type names are gone. Renaming is also possible.