### PR TITLE
Reset password with token received by e-mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v0.5.3-dev (2019-mm-dd)
 
+- new(web): Extended admin frontend
+- new(web): Reset passwords by e-mail
+
 ## v0.5.2 (2019-03-18)
 
 - fix(db): Retarget entry search and optimize tag lookup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "openfairdb"
 version = "0.5.3-dev"
 dependencies = [
+ "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2586,6 +2592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
 "checksum blowfish 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aeb80d00f2688459b8542068abd974cfb101e7a82182414a99b5026c0d85cc3"
+"checksum bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0de79cfb98e7aa9988188784d8664b4b5dad6eaaa0863b91d9a4ed871d4f7a42"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 geocoding = { git = "https://github.com/georust/geocoding" }
 
 [dependencies]
+bs58 = "*"
 chrono = "*"
 # clap 3 is supposed to introduce breaking changes
 clap = "2"

--- a/migrations/2019-03-10_email_token_credentials/down.sql
+++ b/migrations/2019-03-10_email_token_credentials/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE email_token_credentials;

--- a/migrations/2019-03-10_email_token_credentials/up.sql
+++ b/migrations/2019-03-10_email_token_credentials/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE email_token_credentials (
+    id          INTEGER PRIMARY KEY,
+    expires_at  INTEGER NOT NULL,
+    username    TEXT NOT NULL,
+    email       TEXT NOT NULL,
+    nonce       TEXT NOT NULL,
+    UNIQUE      (username),
+    UNIQUE      (nonce),
+    FOREIGN KEY (username) REFERENCES users(username)
+);

--- a/src/adapters/json.rs
+++ b/src/adapters/json.rs
@@ -284,3 +284,15 @@ impl Entry {
         }
     }
 }
+
+#[derive(Deserialize)]
+pub struct RequestPasswordReset {
+    pub email_or_username: String,
+}
+
+#[derive(Deserialize)]
+pub struct ResetPassword {
+    pub email_or_username: String,
+    pub token: String,
+    pub new_password: String,
+}

--- a/src/adapters/user_communication.rs
+++ b/src/adapters/user_communication.rs
@@ -14,6 +14,15 @@ pub fn user_registration_email(url: &str) -> EmailContent {
     EmailContent { subject, body }
 }
 
+pub fn user_password_reset_email(url: &str) -> EmailContent {
+    let subject = "Karte von morgen: Passwort zurücksetzen".into();
+    let body = format!(
+        "Na du Weltverbesserer*,\nhast Du uns kürzlich gebeten Dein Passwort zurücksetzen?\n\nBitte folge zur Eingabe eines neuen Passworts diesem Link:\n{}\n\neuphorische Grüße\ndas Karte von morgen-Team",
+        url,
+    );
+    EmailContent { subject, body }
+}
+
 pub fn entry_added_email(e: &Entry, category_names: &[String]) -> EmailContent {
     let subject = format!("Karte von morgen - neuer Eintrag: {}", e.title);
     let intro_sentence = "ein neuer Eintrag auf der Karte von morgen wurde erstellt";

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -63,6 +63,7 @@ pub trait Db:
     + OrganizationGateway
     + CommentRepository
     + RatingRepository
+    + EmailTokenCredentialsRepository
 {
     fn create_tag_if_it_does_not_exist(&self, _: &Tag) -> Result<()>;
     fn create_category_if_it_does_not_exist(&mut self, _: &Category) -> Result<()>;

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -73,6 +73,12 @@ quick_error! {
         InvalidLimit{
             description("Invalid limit")
         }
+        TokenExpired{
+            description("Token expired")
+        }
+        InvalidNonce{
+            description("Invalid nonce")
+        }
     }
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,7 +15,9 @@ pub mod prelude {
     pub use super::repositories::*;
     pub use super::util::{
         geo::{Distance, LatCoord, LngCoord, MapPoint},
+        nonce::Nonce,
         password::Password,
+        rowid::RowId,
         time::Timestamp,
     };
 

--- a/src/core/repositories.rs
+++ b/src/core/repositories.rs
@@ -53,3 +53,18 @@ pub trait RatingRepository {
 
     fn load_entry_ids_of_ratings(&self, ids: &[&str]) -> Result<Vec<String>>;
 }
+
+pub trait EmailTokenCredentialsRepository {
+    fn replace_email_token_credentials(
+        &self,
+        email_token_credentials: EmailTokenCredentials,
+    ) -> Result<EmailTokenCredentials>;
+
+    fn consume_email_token_credentials(
+        &self,
+        email_or_username: &str,
+        token: &EmailToken,
+    ) -> Result<EmailTokenCredentials>;
+
+    fn discard_expired_email_token_credentials(&self, expired_before: Timestamp) -> Result<usize>;
+}

--- a/src/core/usecases/confirm_email_and_reset_password.rs
+++ b/src/core/usecases/confirm_email_and_reset_password.rs
@@ -1,0 +1,25 @@
+use super::*;
+
+use crate::core::error::{Error, ParameterError};
+
+pub fn confirm_email_and_reset_password<D: Db>(
+    db: &D,
+    username: &str,
+    email: &str,
+    new_password: Password,
+) -> Result<()> {
+    info!("Resetting password for user ({})", username);
+    let mut user = db.get_user(username)?;
+    debug_assert_eq!(user.username, username);
+    if user.email != email {
+        warn!(
+            "Invalid e-mail address for user ({}): expected = {}, actual = {}",
+            user.username, user.email, email,
+        );
+        return Err(Error::Parameter(ParameterError::Email));
+    }
+    user.email_confirmed = true;
+    user.password = new_password;
+    db.update_user(&user)?;
+    Ok(())
+}

--- a/src/core/usecases/create_new_user.rs
+++ b/src/core/usecases/create_new_user.rs
@@ -11,7 +11,7 @@ pub struct NewUser {
     pub email: String,
 }
 
-pub fn create_new_user<D: UserGateway>(db: &mut D, u: NewUser) -> Result<()> {
+pub fn create_new_user<D: UserGateway>(db: &D, u: NewUser) -> Result<()> {
     validate::username(&u.username)?;
     let password = u.password.parse::<Password>()?;
     validate::email(&u.email)?;
@@ -51,7 +51,7 @@ pub fn generate_username_from_email(email: &str) -> String {
     generated_username
 }
 
-pub fn create_user_from_email<D: Db>(db: &mut D, email: &str) -> Result<String> {
+pub fn create_user_from_email<D: Db>(db: &D, email: &str) -> Result<String> {
     let users: Vec<_> = db.all_users()?;
     let username = match users.iter().find(|u| u.email == email) {
         Some(u) => u.username.clone(),

--- a/src/core/usecases/email_token_credentials.rs
+++ b/src/core/usecases/email_token_credentials.rs
@@ -1,0 +1,37 @@
+use crate::core::prelude::*;
+
+use chrono::{Duration, Utc};
+
+pub fn refresh_email_token_credentials<D: Db>(
+    db: &D,
+    username: String,
+    email: String,
+) -> Result<EmailTokenCredentials> {
+    let token = EmailToken {
+        email,
+        nonce: Nonce::new(),
+    };
+    let credentials = EmailTokenCredentials {
+        expires_at: Timestamp::from(Utc::now() + Duration::days(1)),
+        username,
+        token,
+    };
+    Ok(db.replace_email_token_credentials(credentials)?)
+}
+
+pub fn consume_email_token_credentials<D: Db>(
+    db: &D,
+    email_or_username: &str,
+    token: &EmailToken,
+) -> Result<EmailTokenCredentials> {
+    let credentials = db.consume_email_token_credentials(email_or_username, token)?;
+    if credentials.expires_at < Timestamp::now() {
+        return Err(Error::Parameter(ParameterError::TokenExpired));
+    }
+    Ok(credentials)
+}
+
+pub fn discard_expired_email_token_credentials<D: Db>(db: &D) -> Result<usize> {
+    let expired_before = Timestamp::now();
+    Ok(db.discard_expired_email_token_credentials(expired_before)?)
+}

--- a/src/core/usecases/mod.rs
+++ b/src/core/usecases/mod.rs
@@ -14,10 +14,12 @@ mod archive_entries;
 mod archive_events;
 mod archive_ratings;
 mod confirm_email;
+mod confirm_email_and_reset_password;
 mod create_new_entry;
 mod create_new_event;
 pub mod create_new_user;
 mod delete_event;
+mod email_token_credentials;
 mod find_duplicates;
 mod indexing;
 mod login;
@@ -32,9 +34,10 @@ mod update_event;
 
 pub use self::{
     archive_comments::*, archive_entries::*, archive_events::*, archive_ratings::*,
-    confirm_email::*, create_new_entry::*, create_new_event::*, create_new_user::*,
-    delete_event::*, find_duplicates::*, indexing::*, login::*, query_events::*, rate_entry::*,
-    register::*, search::*, update_entry::*, update_event::*,
+    confirm_email::*, confirm_email_and_reset_password::*, create_new_entry::*,
+    create_new_event::*, create_new_user::*, delete_event::*, email_token_credentials::*,
+    find_duplicates::*, indexing::*, login::*, query_events::*, rate_entry::*, register::*,
+    search::*, update_entry::*, update_event::*,
 };
 
 pub fn load_ratings_with_comments<D: Db>(

--- a/src/core/util/mod.rs
+++ b/src/core/util/mod.rs
@@ -1,7 +1,9 @@
 pub mod filter;
 pub mod geo;
+pub mod nonce;
 pub mod parse;
 pub mod password;
+pub mod rowid;
 pub mod sort;
 pub mod time;
 pub mod validate;

--- a/src/core/util/nonce.rs
+++ b/src/core/util/nonce.rs
@@ -1,0 +1,80 @@
+use crate::core::error::{Error, ParameterError};
+
+use std::{fmt, ops::Deref, str::FromStr};
+use uuid::Uuid;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Nonce(Uuid);
+
+impl Nonce {
+    pub const STR_LEN: usize = 32;
+
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl From<Uuid> for Nonce {
+    fn from(from: Uuid) -> Self {
+        Self(from)
+    }
+}
+
+impl From<Nonce> for Uuid {
+    fn from(from: Nonce) -> Self {
+        from.0
+    }
+}
+
+impl AsRef<Uuid> for Nonce {
+    fn as_ref(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl Deref for Nonce {
+    type Target = Uuid;
+
+    fn deref(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl FromStr for Nonce {
+    type Err = Error;
+
+    fn from_str(nonce_str: &str) -> Result<Self, Self::Err> {
+        nonce_str
+            .parse::<Uuid>()
+            .map(Into::into)
+            .map_err(|_| Error::Parameter(ParameterError::InvalidNonce))
+    }
+}
+
+impl fmt::Display for Nonce {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", self.0.to_simple_ref().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_generate_unique_instances() {
+        let n1 = Nonce::new();
+        let n2 = Nonce::new();
+        assert_ne!(n1, n2);
+    }
+
+    #[test]
+    fn should_convert_from_to_string() {
+        let n1 = Nonce::new();
+        let s1 = n1.to_string();
+        assert_eq!(Nonce::STR_LEN, s1.len());
+        let n2 = s1.parse::<Nonce>().unwrap();
+        assert_eq!(n1, n2);
+        assert_eq!(s1, n2.to_string());
+    }
+}

--- a/src/core/util/rowid.rs
+++ b/src/core/util/rowid.rs
@@ -1,0 +1,22 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RowId(i64);
+
+impl From<RowId> for i64 {
+    fn from(from: RowId) -> Self {
+        from.0
+    }
+}
+
+impl From<i64> for RowId {
+    fn from(from: i64) -> Self {
+        Self(from)
+    }
+}
+
+impl fmt::Display for RowId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", self.0)
+    }
+}

--- a/src/infrastructure/db/sqlite/schema.rs
+++ b/src/infrastructure/db/sqlite/schema.rs
@@ -137,6 +137,16 @@ table! {
 }
 
 table! {
+    email_token_credentials (id) {
+        id -> BigInt,
+        expires_at -> BigInt,
+        username -> Text,
+        email -> Text,
+        nonce -> Text,
+    }
+}
+
+table! {
     organizations (id) {
         id -> Text,
         name -> Text,
@@ -153,6 +163,7 @@ joinable!(event_tag_relations -> tags (tag_id));
 joinable!(events -> users (created_by));
 joinable!(org_tag_relations -> organizations (org_id));
 joinable!(org_tag_relations -> tags (tag_id));
+joinable!(email_token_credentials -> users (username));
 
 allow_tables_to_appear_in_same_query!(
     bbox_subscriptions,
@@ -168,4 +179,5 @@ allow_tables_to_appear_in_same_query!(
     ratings,
     tags,
     users,
+    email_token_credentials,
 );

--- a/src/infrastructure/flows/mod.rs
+++ b/src/infrastructure/flows/mod.rs
@@ -4,12 +4,13 @@ mod archive_events;
 mod archive_ratings;
 mod create_entry;
 mod create_rating;
+mod reset_password;
 mod update_entry;
 
 pub mod prelude {
     pub use super::{
         archive_comments::*, archive_entries::*, archive_events::*, archive_ratings::*,
-        create_entry::*, create_rating::*, update_entry::*,
+        create_entry::*, create_rating::*, reset_password::*, update_entry::*,
     };
 }
 
@@ -151,6 +152,11 @@ mod tests {
                     ..Default::default()
                 };
                 self.query_entries(&query)
+            }
+
+            pub fn create_user_from_email(self: &EnvFixture, email: &str) -> String {
+                usecases::create_user_from_email(&*self.db_connections.exclusive().unwrap(), email)
+                    .unwrap()
             }
         }
 

--- a/src/infrastructure/flows/reset_password.rs
+++ b/src/infrastructure/flows/reset_password.rs
@@ -1,0 +1,277 @@
+use super::*;
+
+use crate::core::error::Error;
+
+use diesel::connection::Connection;
+
+// Try to load users either by e-mail (1st) or by username (2nd)
+fn load_users_by_email_or_username<D: UserGateway>(
+    db: &D,
+    email_or_username: &str,
+) -> Result<Vec<User>> {
+    // Try with the username first (if available)
+    match db.get_users_by_email(email_or_username) {
+        Err(RepoError::NotFound) => {
+            let user = db.get_user(email_or_username)?;
+            Ok(vec![user])
+        }
+        res => {
+            let users = res?;
+            debug_assert!(!users.is_empty());
+            if let Ok(user) = db.get_user(email_or_username) {
+                for u in &users {
+                    if u.username == user.username {
+                        return Ok(vec![user]);
+                    }
+                }
+                error!(
+                    "Search results for users with e-mail or username '{}' are ambiguous!",
+                    email_or_username
+                );
+                Err(RepoError::NotFound)?;
+            }
+            Ok(users)
+        }
+    }
+}
+
+fn refresh_email_token_credentials(
+    connections: &sqlite::Connections,
+    user: &User,
+) -> Result<EmailTokenCredentials> {
+    let mut rollback_err: Option<Error> = None;
+    let connection = connections.exclusive()?;
+    Ok(connection
+        .transaction::<_, diesel::result::Error, _>(|| {
+            usecases::refresh_email_token_credentials(
+                &*connection,
+                user.username.to_owned(),
+                user.email.to_owned(),
+            )
+            .map_err(|err| {
+                rollback_err = Some(err);
+                diesel::result::Error::RollbackTransaction
+            })
+        })
+        .map_err(|err| rollback_err.unwrap_or_else(|| Error::from(RepoError::from(err))))?)
+}
+
+pub fn request_password_reset(
+    connections: &sqlite::Connections,
+    email_or_username: &str,
+) -> Result<Vec<EmailToken>> {
+    // The user is loaded before the following transaction that
+    // requires exclusive access to the database connection for
+    // writing.
+    let users = load_users_by_email_or_username(&*connections.shared()?, email_or_username)?;
+    if users.len() > 1 {
+        warn!(
+            "Requesting password reset for all ({}) users with e-mail address '{}'",
+            users.len(),
+            users[0].email
+        );
+    }
+
+    let mut tokens = Vec::with_capacity(users.len());
+    for user in &users {
+        let credentials = refresh_email_token_credentials(&connections, &user)?;
+        notify::user_password_reset_requested(&credentials.token);
+        tokens.push(credentials.token);
+    }
+
+    Ok(tokens)
+}
+
+pub fn reset_password_with_email_token(
+    connections: &sqlite::Connections,
+    email_or_username: &str,
+    token: EmailToken,
+    new_password: Password,
+) -> Result<()> {
+    let connection = connections.exclusive()?;
+
+    // The token should be consumed only once, even if the
+    // following transaction for updating the user fails!
+    let mut rollback_err: Option<Error> = None;
+    let credentials = connection
+        .transaction::<_, diesel::result::Error, _>(|| {
+            usecases::consume_email_token_credentials(&*connection, email_or_username, &token)
+                .map_err(|err| {
+                    warn!(
+                        "Missing or invalid token to reset password for user '{}': {}",
+                        email_or_username, err
+                    );
+                    rollback_err = Some(err);
+                    diesel::result::Error::RollbackTransaction
+                })
+        })
+        .map_err(|err| rollback_err.unwrap_or_else(|| Error::from(RepoError::from(err))))?;
+
+    // The consumed nonce must match the request parameters
+    debug_assert!(credentials.token == token);
+
+    // Verify and update the user entity
+    let mut rollback_err: Option<Error> = None;
+    connection
+        .transaction::<_, diesel::result::Error, _>(|| {
+            usecases::confirm_email_and_reset_password(
+                &*connection,
+                &credentials.username,
+                &credentials.token.email,
+                new_password,
+            )
+            .map_err(|err| {
+                warn!(
+                    "Failed to verify e-mail ({}) and reset password for user ({}): {}",
+                    credentials.token.email, credentials.username, err
+                );
+                rollback_err = Some(err);
+                diesel::result::Error::RollbackTransaction
+            })
+        })
+        .map_err(|err| rollback_err.unwrap_or_else(|| Error::from(RepoError::from(err))))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::prelude::*;
+
+    fn request_password_reset(
+        fixture: &EnvFixture,
+        email_or_username: &str,
+    ) -> super::Result<Vec<EmailToken>> {
+        super::request_password_reset(&fixture.db_connections, email_or_username)
+    }
+
+    fn reset_password_with_email_token(
+        fixture: &EnvFixture,
+        email_or_username: &str,
+        token: EmailToken,
+        new_password: Password,
+    ) -> super::Result<()> {
+        super::reset_password_with_email_token(
+            &fixture.db_connections,
+            email_or_username,
+            token,
+            new_password,
+        )
+    }
+
+    #[test]
+    fn should_reset_password() {
+        let fixture = EnvFixture::new();
+
+        // User 1
+        let email1 = "user1@some.org";
+        let username1 = fixture.create_user_from_email(email1);
+        let credentials1 = usecases::Credentials {
+            email: &email1,
+            password: "new pass1",
+        };
+
+        // User 2
+        let email2 = "user2@some.org";
+        let username2 = fixture.create_user_from_email(email2);
+        let credentials2 = usecases::Credentials {
+            email: &email2,
+            password: "new pass2",
+        };
+
+        // Verify that password is invalid for both users
+        debug_assert!(usecases::login_with_email(
+            &*fixture.db_connections.shared().unwrap(),
+            &credentials1
+        )
+        .is_err());
+        debug_assert!(usecases::login_with_email(
+            &*fixture.db_connections.shared().unwrap(),
+            &credentials2
+        )
+        .is_err());
+
+        // Request and reset password for user 1 (by email)
+        let tokens = request_password_reset(&fixture, email1).unwrap();
+        assert_eq!(1, tokens.len());
+        let token1 = tokens.into_iter().next().unwrap();
+        assert_eq!(email1, token1.email);
+        // Verify that we are not able to reset the password of another user with this token
+        assert!(reset_password_with_email_token(
+            &fixture,
+            email2,
+            token1.clone(),
+            credentials2.password.parse::<Password>().unwrap()
+        )
+        .is_err());
+        // Reset the password of user 1
+        assert!(reset_password_with_email_token(
+            &fixture,
+            email1,
+            token1.clone(),
+            credentials1.password.parse::<Password>().unwrap()
+        )
+        .is_ok());
+        // Verify that a 2nd attempt to reset the password with the same token fails
+        assert!(reset_password_with_email_token(
+            &fixture,
+            email1,
+            token1,
+            credentials1.password.parse::<Password>().unwrap()
+        )
+        .is_err());
+
+        // Check that user 1 is able to login with the new password
+        debug_assert!(usecases::login_with_email(
+            &*fixture.db_connections.shared().unwrap(),
+            &credentials1
+        )
+        .is_ok());
+        debug_assert!(usecases::login_with_email(
+            &*fixture.db_connections.shared().unwrap(),
+            &credentials2
+        )
+        .is_err());
+
+        // Request and reset password for user 2 (by username)
+        let tokens = request_password_reset(&fixture, &username2).unwrap();
+        assert_eq!(1, tokens.len());
+        let token2 = tokens.into_iter().next().unwrap();
+        assert_eq!(email2, token2.email);
+        // Verify that we are not able to reset the password of another user with this token
+        assert!(reset_password_with_email_token(
+            &fixture,
+            &username1,
+            token2.clone(),
+            credentials1.password.parse::<Password>().unwrap()
+        )
+        .is_err());
+        // Reset the password of user 2
+        assert!(reset_password_with_email_token(
+            &fixture,
+            &username2,
+            token2.clone(),
+            credentials2.password.parse::<Password>().unwrap()
+        )
+        .is_ok());
+        // Verify that a 2nd attempt to reset the password with the same token fails
+        assert!(reset_password_with_email_token(
+            &fixture,
+            &username2,
+            token2,
+            credentials2.password.parse::<Password>().unwrap()
+        )
+        .is_err());
+
+        // Check that both users are able to login with their new passwords
+        debug_assert!(usecases::login_with_email(
+            &*fixture.db_connections.shared().unwrap(),
+            &credentials1
+        )
+        .is_ok());
+        debug_assert!(usecases::login_with_email(
+            &*fixture.db_connections.shared().unwrap(),
+            &credentials2
+        )
+        .is_ok());
+    }
+}

--- a/src/infrastructure/notify.rs
+++ b/src/infrastructure/notify.rs
@@ -94,3 +94,20 @@ pub fn user_registered(user: &User, url: &str) {
         compose_and_send_email(&user.email, &content.subject, &content.body);
     }
 }
+
+pub fn user_password_reset_requested(token: &EmailToken) {
+    let url = format!(
+        "https://kartevonmorgen.org/#/?reset_password={}",
+        token.encode_to_string()
+    );
+    let content = user_communication::user_password_reset_email(&url);
+
+    #[cfg(feature = "email")]
+    {
+        info!(
+            "Sending e-mail to {} after password reset requested",
+            token.email
+        );
+        compose_and_send_emails(&[token.email.to_owned()], &content.subject, &content.body);
+    }
+}

--- a/src/ports/web/api/mod.rs
+++ b/src/ports/web/api/mod.rs
@@ -57,6 +57,8 @@ pub fn routes() -> Vec<Route> {
         events::put_event_with_token,
         events::delete_event,
         events::delete_event_with_token,
+        users::post_request_password_reset,
+        users::post_reset_password,
         users::post_user,
         ratings::post_rating,
         ratings::load_rating,

--- a/src/ports/web/mod.rs
+++ b/src/ports/web/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{db::EntryIndexer, prelude::*, util::sort::Rated},
+    core::{db::EntryIndexer, prelude::*, usecases, util::sort::Rated},
     infrastructure::error::AppError,
 };
 use rocket::{config::Config, Rocket, Route};
@@ -46,6 +46,9 @@ pub(crate) fn rocket_instance(
 ) -> Rocket {
     info!("Indexing all entries...");
     index_all_entries(&*connections.exclusive().unwrap(), &mut search_engine).unwrap();
+
+    info!("Discarding expired user e-mail nonces...");
+    usecases::discard_expired_email_token_credentials(&*connections.exclusive().unwrap()).unwrap();
 
     info!("Initialization finished");
     let r = match cfg {


### PR DESCRIPTION
Implements all functions required by the backend, including sending out e-mails. Text and link in the e-mail might need to be adjusted. A test for the involved flows is in place.

The form presented to the user should contain the following input fields:
* username or e-mail (the backend is able to figure this out)
* new password
* new password (repeated)

The user's e-mail is also encoded in the token itself (not encrypted, just base58 encoded) and strictly speaking not needed. But by lettings the user identify themselves we ensure that they are aware of the context and the backend is able to check for consistency once again when receiving the credentials.