### PR TITLE
Recently changed entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.8 (2019-08-14)
+
+- new(web): New endpoint /entries/recently-changed for retrieving recent changes
+
 ## v0.5.7 (2019-07-24)
 
 - fix(db): Adjust scoring of search results

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -91,6 +91,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/Entry'
 
+  '/entries/recently-changed':
+    get:
+      summary: Get recently changed entries that have been created/updated/archived between since and now
+      tags:
+        - Entries
+      parameters:
+        - name: since
+          in: query
+          required: true
+          description: Time stamp of the latest change that should be included
+          schema:
+            $ref: '#/components/schemas/UnixTime'
+        - name: with_ratings
+          in: query
+          description: Return entries including their ratings
+          schema:
+            type: boolean
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationOffset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entry'
+
   '/ratings/{ids}':
     get:
       summary: Get multiple ratings
@@ -668,6 +695,24 @@ components:
       schema:
         type: string
         example: '42.27,-7.97,52.58,38.25'
+    PaginationLimit:
+      name: limit
+      in: query
+      required: false
+      description: Maximum number of items to return or implicit/unlimited if unspecified.
+      schema:
+        type: integer
+        format: int64
+        example: 100
+    PaginationOffset:
+      name: offset
+      in: query
+      required: false
+      description: Number of items to skip in the result list or 0 if unspecified.
+      schema:
+        type: integer
+        format: int64
+        example: 1000
   securitySchemes:
     bearerAuth:
       type: http

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -23,6 +23,13 @@ pub trait EntryGateway {
     fn update_entry(&self, _: &Entry) -> Result<()>;
     fn import_multiple_entries(&mut self, _: &[Entry]) -> Result<()>;
     fn archive_entries(&self, ids: &[&str], archived: Timestamp) -> Result<usize>;
+
+    fn recently_changed_entries(
+        &self,
+        since: Timestamp,
+        offset: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<Vec<Entry>>;
 }
 
 pub trait EventGateway {

--- a/src/core/usecases/tests.rs
+++ b/src/core/usecases/tests.rs
@@ -247,6 +247,14 @@ impl EntryGateway for MockDb {
             .cloned()
             .collect())
     }
+    fn recently_changed_entries(
+        &self,
+        _since: Timestamp,
+        offset: Option<u64>,
+        limit: Option<u64>,
+    ) -> RepoResult<Vec<Entry>> {
+        unimplemented!();
+    }
     fn count_entries(&self) -> RepoResult<usize> {
         self.all_entries().map(|v| v.len())
     }

--- a/src/core/usecases/tests.rs
+++ b/src/core/usecases/tests.rs
@@ -250,8 +250,8 @@ impl EntryGateway for MockDb {
     fn recently_changed_entries(
         &self,
         _since: Timestamp,
-        offset: Option<u64>,
-        limit: Option<u64>,
+        _offset: Option<u64>,
+        _limit: Option<u64>,
     ) -> RepoResult<Vec<Entry>> {
         unimplemented!();
     }

--- a/src/infrastructure/db/sqlite/connection.rs
+++ b/src/infrastructure/db/sqlite/connection.rs
@@ -244,6 +244,97 @@ impl EntryGateway for SqliteConnection {
         Ok(res_entries)
     }
 
+    fn recently_changed_entries(
+        &self,
+        since: Timestamp,
+        offset: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<Vec<Entry>> {
+        use self::schema::{
+            entries::dsl as e_dsl, entry_category_relations::dsl as e_c_dsl,
+            entry_tag_relations::dsl as e_t_dsl,
+        };
+        // TODO: Don't load all table contents into memory at once!
+        // We only need to iterator over the sorted rows of the results.
+        // Unfortunately Diesel does not offer a Cursor API.
+        let changed_expr =
+            diesel::dsl::sql::<diesel::sql_types::BigInt>("COALESCE(archived, created)");
+        let mut query = e_dsl::entries
+            .filter(e_dsl::current.eq(true))
+            .filter(changed_expr.clone().ge(i64::from(since)))
+            .order_by(changed_expr.clone().desc())
+            .order_by(e_dsl::id) // disambiguation if time stamps are equal
+            .into_boxed();
+        let offset = offset.unwrap_or(0);
+        if offset > 0 {
+            query = query.offset(offset as i64);
+        }
+        if let Some(limit) = limit {
+            query = query.limit(limit as i64);
+        }
+        let entries: Vec<models::Entry> = query.load(self)?;
+        let mut cat_rels = e_c_dsl::entry_category_relations
+            .order_by(e_c_dsl::entry_id)
+            .load(self)?
+            .into_iter()
+            .peekable();
+        let mut tag_rels = e_t_dsl::entry_tag_relations
+            .order_by(e_t_dsl::entry_id)
+            .load(self)?
+            .into_iter()
+            .peekable();
+        let mut res_entries = Vec::with_capacity(entries.len());
+        // All results are sorted by entry id and we only need to iterate
+        // once through the results to pick up the categories and tags of
+        // each entry.
+        for entry in entries.into_iter() {
+            let mut categories = Vec::with_capacity(10);
+            let mut tags = Vec::with_capacity(100);
+            // Skip orphaned/deleted relations for which no current entry exists
+            while let Some(true) = cat_rels
+                .peek()
+                .map(|ec: &models::EntryCategoryRelation| ec.entry_id < entry.id)
+            {
+                let _ = cat_rels.next();
+            }
+            while let Some(true) = tag_rels
+                .peek()
+                .map(|et: &models::EntryTagRelation| et.entry_id < entry.id)
+            {
+                let _ = tag_rels.next();
+            }
+            // Collect categories of the current entry
+            while let Some(true) = cat_rels
+                .peek()
+                .map(|ec: &models::EntryCategoryRelation| ec.entry_id == entry.id)
+            {
+                let cat_rel = cat_rels.next().unwrap();
+                if cat_rel.entry_version != entry.version {
+                    // Skip category relation with outdated version
+                    debug_assert!(cat_rel.entry_version < entry.version);
+                } else {
+                    categories.push(cat_rel.category_id);
+                }
+            }
+            // Collect tags of entry
+            while let Some(true) = tag_rels
+                .peek()
+                .map(|et: &models::EntryTagRelation| et.entry_id == entry.id)
+            {
+                let tag_rel = tag_rels.next().unwrap();
+                if tag_rel.entry_version != entry.version {
+                    // Skip tag relation with outdated version
+                    debug_assert!(tag_rel.entry_version < entry.version);
+                } else {
+                    tags.push(tag_rel.tag_id);
+                }
+            }
+            // Convert into result entry
+            res_entries.push((entry, categories, tags).into());
+        }
+        Ok(res_entries)
+    }
+
     fn count_entries(&self) -> Result<usize> {
         use self::schema::entries::dsl as e_dsl;
         Ok(e_dsl::entries


### PR DESCRIPTION
Implements #198 (no bbox filtering)

Example:
```
http://localhost:6767/api/entries/recently-changed?since=1565446276&offset=0&limit=100
```