### PR TITLE
Optimize filtering of events by start_min/start_max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.5.8 (2019-08-14)
 
 - new(web): New endpoint /entries/recently-changed for retrieving recent changes
+- chore(db): Optimize filtering of events by start_min/start_max
 
 ## v0.5.7 (2019-07-24)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,12 +632,11 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz_oxide_c_api 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1166,17 +1165,6 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "miniz_oxide_c_api"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1900,7 +1888,7 @@ dependencies = [
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2842,7 +2830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fast_chemail 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
 "checksum filetime 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2f8c63033fcba1f51ef744505b3cad42510432b904c062afa67ad7ece008429d"
-"checksum flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8"
+"checksum flate2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cf841b06fbfde1bf4ffc2c42e25cc539ccdafe9fed0bd1264000317d8a5e83c6"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
@@ -2905,7 +2893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7108aff85b876d06f22503dcce091e29f76733b2bfdd91eebce81f5e68203a10"
-"checksum miniz_oxide_c_api 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6c675792957b0d19933816c4e1d56663c341dd9bfa31cb2140ff2267c1d8ecf4"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -36,6 +36,11 @@ pub trait EventGateway {
     fn create_event(&self, _: Event) -> Result<()>;
     fn get_event(&self, _: &str) -> Result<Event>;
     fn all_events(&self) -> Result<Vec<Event>>;
+    fn get_events(
+        &self,
+        start_min: Option<Timestamp>,
+        start_max: Option<Timestamp>,
+    ) -> Result<Vec<Event>>;
     fn update_event(&self, _: &Event) -> Result<()>;
     fn archive_events(&self, ids: &[&str], archived: Timestamp) -> Result<usize>;
     fn delete_event(&self, _: &str) -> Result<()>;

--- a/src/core/usecases/query_events.rs
+++ b/src/core/usecases/query_events.rs
@@ -26,18 +26,12 @@ pub fn query_events<D: Db>(
         None
     };
 
-    let mut events = db.all_events()?;
+    let mut events = db.get_events(start_min.map(Into::into), start_max.map(Into::into))?;
 
     if let Some(bbox) = bbox.as_ref().map(filter::extend_bbox) {
         events = events.into_iter().filter(|x| x.in_bbox(&bbox)).collect();
     }
 
-    if let Some(min) = start_min {
-        events = events.into_iter().filter(|e| e.start >= min).collect();
-    }
-    if let Some(max) = start_max {
-        events = events.into_iter().filter(|e| e.start <= max).collect();
-    }
     if let Some(tags) = tags {
         events = events
             .into_iter()

--- a/src/core/usecases/tests.rs
+++ b/src/core/usecases/tests.rs
@@ -297,6 +297,34 @@ impl EventGateway for MockDb {
             .collect())
     }
 
+    fn get_events(
+        &self,
+        start_min: Option<Timestamp>,
+        start_max: Option<Timestamp>,
+    ) -> RepoResult<Vec<Event>> {
+        Ok(self
+            .events
+            .borrow()
+            .iter()
+            .filter(|e| e.archived.is_none())
+            .filter(|e| {
+                if let Some(start_min) = start_min {
+                    e.start >= start_min.into()
+                } else {
+                    true
+                }
+            })
+            .filter(|e| {
+                if let Some(start_max) = start_max {
+                    e.start <= start_max.into()
+                } else {
+                    true
+                }
+            })
+            .cloned()
+            .collect())
+    }
+
     fn count_events(&self) -> RepoResult<usize> {
         self.all_events().map(|v| v.len())
     }

--- a/src/core/util/time.rs
+++ b/src/core/util/time.rs
@@ -23,6 +23,18 @@ impl From<i64> for Timestamp {
     }
 }
 
+impl From<NaiveDateTime> for Timestamp {
+    fn from(from: NaiveDateTime) -> Self {
+        Self(from.timestamp())
+    }
+}
+
+impl From<Timestamp> for NaiveDateTime {
+    fn from(from: Timestamp) -> Self {
+        NaiveDateTime::from_timestamp(from.0, 0)
+    }
+}
+
 impl From<DateTime<Utc>> for Timestamp {
     fn from(from: DateTime<Utc>) -> Self {
         Self(from.timestamp())
@@ -31,7 +43,7 @@ impl From<DateTime<Utc>> for Timestamp {
 
 impl From<Timestamp> for DateTime<Utc> {
     fn from(from: Timestamp) -> Self {
-        Self::from_utc(NaiveDateTime::from_timestamp(from.0, 0), Utc)
+        Self::from_utc(NaiveDateTime::from(from), Utc)
     }
 }
 


### PR DESCRIPTION
Partially fixes #197 by filtering events by their start time in the database.