### PR TITLE
Fix merging of tags and categories for recently changed entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## next (unreleased)
+## v0.6.3 (2019-10-25)
 
 - new home: [kartevonmorgen/openfairdb](https://github.com/kartevonmorgen/openfairdb)
+- fix(db): Fix merging of tags and categories for recently changed entries
 
 ## v0.6.2 (2019-10-15)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,7 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openfairdb"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openfairdb"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Markus Kohlhase <mail@markus-kohlhase.de>", "slowtec GmbH <post@slowtec.de>"]
 keywords = ["geo", "fair", "sustainability"]
 homepage = "https://github.com/kartevonmorgen/openfairdb"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: OpenFairDB API
-  version: 0.6.2
+  version: 0.6.3
   contact:
     name: slowtec GmbH
     url: 'https://slowtec.de'


### PR DESCRIPTION
Fixes #209 

Merging categories and tags into the query results efficiently is non-trivial. A normalized, relational schema is not a good fit for this use case.

Unfortunately, there are still no tests that could have helped to detect this bug early. Writing a test setup that covers all possible data constellations would be tedious.