### PR TITLE
Add route to check if a place already exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - new(web/db): Moderated tags: Fine-grained permissions for organizations
 - new(web/db): Clearance: Allow organizations to manually *clear* new place/entry revisions after editing
 - new (web/db): Clearance: Optionally replace or exclude revisions with *pending clearance* from search results, i.e. return an older, already cleared revision if available
+- new(api): check for duplicates (`/duplicates/check-place`)
 
 ## v0.8.21 (2020-08-04)
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -777,6 +777,24 @@ paths:
                 type: string
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+  /duplicates/check-place:
+    post:
+      summary: Check if a place already exists
+      tags:
+        - Duplicates
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewEntry'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
 components:
   schemas:
     NewEntry:

--- a/src/ports/web/api/duplicates.rs
+++ b/src/ports/web/api/duplicates.rs
@@ -1,0 +1,58 @@
+use super::Result;
+use crate::{
+    core::{
+        prelude::*,
+        usecases::{self, DuplicateType},
+        util,
+    },
+    infrastructure::db::sqlite,
+};
+use rocket_contrib::json::Json;
+
+#[post("/duplicates/check-place", data = "<body>")]
+pub fn post_duplicates(
+    db: sqlite::Connections,
+    body: Json<usecases::NewPlace>,
+) -> Result<Vec<(String, DuplicateType)>> {
+    let new_place = body.into_inner();
+    let possible_duplicate_entries = {
+        // TODO:
+        // Calculate an area of interest (bounding box)
+        // to reduce the amount of analyzed entries.
+        let db = db.shared()?;
+        db.all_places()?
+    };
+    let results =
+        usecases::find_duplicate_of_unregistered_place(&new_place, &possible_duplicate_entries);
+    Ok(Json(
+        results
+            .into_iter()
+            .map(|(id, dup)| (id.to_string(), dup))
+            .collect(),
+    ))
+}
+
+#[get("/duplicates/<ids>")]
+pub fn get_duplicates(
+    db: sqlite::Connections,
+    ids: String,
+) -> Result<Vec<(String, String, DuplicateType)>> {
+    let ids = util::split_ids(&ids);
+    if ids.is_empty() {
+        return Ok(Json(vec![]));
+    }
+    let (entries, possible_duplicate_entries) = {
+        // TODO:
+        // Calculate an area of interest (bounding box)
+        // to reduce the amount of analyzed entries.
+        let db = db.shared()?;
+        (db.get_places(&ids)?, db.all_places()?)
+    };
+    let results = usecases::find_duplicates(&entries, &possible_duplicate_entries);
+    Ok(Json(
+        results
+            .into_iter()
+            .map(|(id1, id2, dup)| (id1.to_string(), id2.to_string(), dup))
+            .collect(),
+    ))
+}

--- a/src/ports/web/api/mod.rs
+++ b/src/ports/web/api/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     adapters::{self, json},
     core::{
         prelude::*,
-        usecases::{self, DuplicateType},
+        usecases,
         util::{self, geo},
     },
     infrastructure::{
@@ -24,6 +24,7 @@ use rocket_contrib::json::Json;
 use std::result;
 
 mod count;
+mod duplicates;
 pub mod events;
 mod places;
 mod ratings;
@@ -33,7 +34,6 @@ pub mod tests;
 mod users;
 
 type Result<T> = result::Result<Json<T>, AppError>;
-
 type StatusResult = result::Result<Status, AppError>;
 
 pub fn routes() -> Vec<Route> {
@@ -76,7 +76,8 @@ pub fn routes() -> Vec<Route> {
         get_category,
         get_tags,
         search::get_search,
-        get_duplicates,
+        duplicates::get_duplicates,
+        duplicates::post_duplicates,
         count::get_count_entries,
         count::get_count_tags,
         get_version,
@@ -309,28 +310,6 @@ pub fn post_places_review(
         );
     }
     Ok(Json(()))
-}
-
-#[get("/duplicates/<ids>")]
-fn get_duplicates(
-    db: sqlite::Connections,
-    ids: String,
-) -> Result<Vec<(String, String, DuplicateType)>> {
-    let ids = util::split_ids(&ids);
-    if ids.is_empty() {
-        return Ok(Json(vec![]));
-    }
-    let (entries, all_entries) = {
-        let db = db.shared()?;
-        (db.get_places(&ids)?, db.all_places()?)
-    };
-    let results = usecases::find_duplicates(&entries, &all_entries);
-    Ok(Json(
-        results
-            .into_iter()
-            .map(|(id1, id2, dup)| (id1.to_string(), id2.to_string(), dup))
-            .collect(),
-    ))
 }
 
 #[get("/server/version")]


### PR DESCRIPTION
@navid-kalaei here is a first draft to fix #257.

During the development you can run
```sh
cargo watch -x "test --tests ports::web::api::tests::check_place_duplicate"
```
to get direct feedback.

ToDo's:

- [x] Finish API description in `openapi.yaml`
- [x] Implement usecase
- [ ] Probably add more tests
- [ ] Calculate bounding box
- [ ] Add a benchmark test
- [ ] Optimize speed