### PR TITLE
[WiP] Enable "bundled" feature of libsqlite3-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,7 @@ name = "libsqlite3-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1499,6 +1500,7 @@ dependencies = [
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fast_chemail 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "maud 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rocket_contrib = "*"
 rocket_cors = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = "*"
+libsqlite3-sys = { version = "*", features = ["bundled"] }
 strum = "*"
 tantivy = "*"
 thiserror = "1"


### PR DESCRIPTION
Currently the development headers of SQLite3 are needed for the build. The "bundled" feature should make them obsolete.

Let's wait if the CI build on GitLab succeeds:
https://gitlab.com/uklotzde/openfairdb/-/pipelines/156738485