### PR TITLE
Provide field with additional links

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -707,6 +707,14 @@ components:
           $ref: '#/components/schemas/Url'
         license:
           $ref: '#/components/schemas/License'
+        links:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                $ref: '#/components/schemas/Url'
+
     EntryWithVersion:
       allOf:
         - $ref: '#/components/schemas/NewEntry'


### PR DESCRIPTION
The API should provide a field width additional links (see https://github.com/kartevonmorgen/kartevonmorgen/issues/723)