### PR TITLE
Filter entries by their clearance revision and status

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -32,6 +32,7 @@ paths:
         - Search
       parameters:
         - $ref: '#/components/parameters/BoundingBox'
+        - $ref: '#/components/parameters/OrgTagFilter'
         - name: categories
           in: query
           schema:
@@ -45,33 +46,6 @@ paths:
           in: query
           schema:
             type: string
-        - name: org_tag
-          in: query
-          schema:
-            type: string
-          description: |
-            A single hash tag that is moderated by an organization.
-
-            The hash tag will be included in the query as a mandatory search criteria
-            like any other tag.
-
-            Results will be filtered according to the current clearance status.
-            Unclear revisions of entries will either be removed or replaced by older,
-            already cleared revisions. Unclear revisions of entries are expected to
-            only exist temporarily for a short time frame until a newer version has been
-            cleared.
-
-            If the provided hash tag is not moderated by any organization the results
-            will not be filtered by clearance status.
-
-            Omitting this parameter and instead appending the moderated hash tag as
-            a regular tag to the `tags` parameter will also return unfiltered search
-            results, i.e. current revisions of entries independent of their
-            clearance status.
-
-            Only a single tag can be specified, because filtering according to
-            clearance by multiple organizations could produce ambiguous and
-            conflicting results.
         - $ref: '#/components/parameters/IdList'
         - $ref: '#/components/parameters/TagList'
         - $ref: '#/components/parameters/ReviewStatusList'
@@ -133,6 +107,7 @@ paths:
         - Entries/Places
       parameters:
         - $ref: '#/components/parameters/IdListPath'
+        - $ref: '#/components/parameters/OrgTagFilter'
       responses:
         '200':
           description: Successful response
@@ -1500,19 +1475,18 @@ components:
       example: 120.7
       description: Geographic longitude (in degrees)
   parameters:
-    BoundingBox:
-      name: bbox
-      in: query
-      description: Bounding Box
-      schema:
-        type: string
-        example: '42.27,-7.97,52.58,38.25'
     IdPath:
       name: id
       in: path
       required: true
       schema:
         $ref: '#/components/schemas/Id'
+    IdListPath:
+      name: ids
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/IdList'
     OptionalRevisionPath:
       name: revision
       in: path
@@ -1521,12 +1495,40 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/Revision'
-    IdListPath:
-      name: ids
-      in: path
-      required: true
+    BoundingBox:
+      name: bbox
+      in: query
+      description: Bounding Box
       schema:
-        $ref: '#/components/schemas/IdList'
+        type: string
+        example: '42.27,-7.97,52.58,38.25'
+    OrgTagFilter:
+      name: org_tag
+      in: query
+      required: false
+      schema:
+        type: string
+      description: |
+        A single hash tag that is moderated by an organization.
+
+        Results will be filtered according to the current clearance status.
+        Unclear revisions of entries will either be removed or replaced by older,
+        already cleared revisions. Unclear revisions of entries are expected to
+        only exist temporarily for a short time frame until a newer version has
+        been cleared.
+
+        If the provided hash tag is not moderated by any organization the results
+        will not be filtered by clearance status.
+
+        Only a single tag can be specified, because filtering according to
+        clearance by multiple organizations could produce ambiguous and
+        conflicting results.
+
+        Only when used in search requests: The hash tag will be included in the
+        query as a mandatory search criteria like any other tag. Omitting this
+        parameter and instead appending the moderated hash tag as a regular tag
+        to the `tags` parameter will also return unfiltered search results, i.e.
+        current revisions of entries independent of their clearance status.
     IdList:
       name: ids
       in: query

--- a/src/core/usecases/clearance/place.rs
+++ b/src/core/usecases/clearance/place.rs
@@ -1,5 +1,7 @@
 use crate::core::prelude::*;
 
+use std::collections::HashMap;
+
 pub(crate) fn add_pending_clearance<R: PlaceClearanceRepo>(
     repo: &R,
     org_ids: &[Id],
@@ -49,4 +51,55 @@ pub fn update_pending_clearances<R: OrganizationRepo + PlaceClearanceRepo>(
     );
     repo.cleanup_pending_clearances_for_places(&org.id)?;
     Ok(count)
+}
+
+pub fn clear_repo_results<R: PlaceRepo + PlaceClearanceRepo>(
+    repo: &R,
+    org_id: &Id,
+    org_tag: &str,
+    results: Vec<(Place, ReviewStatus)>,
+) -> Result<Vec<(Place, ReviewStatus)>> {
+    let place_ids: Vec<_> = results.iter().map(|(p, _)| p.id.as_str()).collect();
+    let pending_clearances = repo.load_pending_clearances_for_places(org_id, &place_ids)?;
+    if pending_clearances.is_empty() {
+        // No filtering required
+        return Ok(results);
+    }
+    let pending_clearances: HashMap<_, _> = pending_clearances
+        .into_iter()
+        .map(|p| (p.place_id.to_string(), p))
+        .collect();
+    let mut cleared_results = Vec::with_capacity(results.len());
+    for (mut place, mut review_status) in results.into_iter() {
+        debug_assert!(place
+            .tags
+            .iter()
+            .map(String::as_str)
+            .any(|tag| tag == org_tag));
+        let pending_clearance = pending_clearances.get(place.id.as_str());
+        if let Some(pending_clearance) = pending_clearance {
+            if let Some(last_cleared_revision) = &pending_clearance.last_cleared_revision {
+                let (last_cleared_place, last_cleared_status) =
+                    repo.load_place_revision(place.id.as_str(), *last_cleared_revision)?;
+                debug_assert_eq!(*last_cleared_revision, last_cleared_place.revision);
+                let last_cleared_tags = &last_cleared_place.tags;
+                if !last_cleared_tags
+                    .iter()
+                    .map(String::as_str)
+                    .any(|tag| tag == org_tag)
+                {
+                    // Remove previously untagged places from the result
+                    continue;
+                }
+                // Replace the actual/current search result item with the last cleared revision
+                place = last_cleared_place;
+                review_status = last_cleared_status;
+            } else {
+                // Skip newly created but not yet cleared entry
+                continue;
+            }
+        }
+        cleared_results.push((place, review_status));
+    }
+    Ok(cleared_results)
 }

--- a/src/core/usecases/load_places.rs
+++ b/src/core/usecases/load_places.rs
@@ -1,0 +1,15 @@
+use crate::core::prelude::*;
+
+pub fn load_places<R: PlaceRepo + PlaceClearanceRepo + OrganizationRepo>(
+    repo: &R,
+    ids: &[&str],
+    org_tag: Option<&str>,
+) -> Result<Vec<(Place, ReviewStatus)>> {
+    let places = repo.get_places(&ids)?;
+    if let Some(org_tag) = org_tag {
+        if let Some(org_id) = repo.map_tag_to_clearance_org_id(org_tag)? {
+            return super::clearance::place::clear_repo_results(repo, &org_id, org_tag, places);
+        }
+    }
+    Ok(places)
+}

--- a/src/core/usecases/mod.rs
+++ b/src/core/usecases/mod.rs
@@ -25,6 +25,7 @@ mod filter_event;
 mod filter_place;
 mod find_duplicates;
 mod indexing;
+mod load_places;
 mod login;
 mod query_events;
 mod rate_place;
@@ -42,8 +43,8 @@ pub use self::{
     archive_comments::*, archive_events::*, archive_ratings::*, authorize::*, change_user_role::*,
     confirm_email::*, confirm_email_and_reset_password::*, create_new_place::*, create_new_user::*,
     delete_event::*, export_event::*, export_place::*, filter_event::*, filter_place::*,
-    find_duplicates::*, indexing::*, login::*, query_events::*, rate_place::*, register::*,
-    review_places::*, search::*, store_event::*, update_place::*, user_tokens::*,
+    find_duplicates::*, indexing::*, load_places::*, login::*, query_events::*, rate_place::*,
+    register::*, review_places::*, search::*, store_event::*, update_place::*, user_tokens::*,
 };
 
 //TODO: move usecases into separate files

--- a/src/ports/web/api/mod.rs
+++ b/src/ports/web/api/mod.rs
@@ -108,13 +108,7 @@ fn get_entry(
     let GetEntryQuery { ref org_tag } = query.into_inner();
     let results = {
         let db = db.shared()?;
-        let mut places = db.get_places(&ids)?;
-        if let Some(org_tag) = org_tag {
-            if let Some(org_id) = db.map_tag_to_clearance_org_id(&org_tag)? {
-                places =
-                    usecases::clearance::place::clear_repo_results(&*db, &org_id, org_tag, places)?;
-            }
-        }
+        let places = usecases::load_places(&*db, &ids, org_tag.as_ref().map(String::as_str))?;
         let mut results = Vec::with_capacity(places.len());
         for (place, _) in places.into_iter() {
             let r = db.load_ratings_of_place(place.id.as_ref())?;


### PR DESCRIPTION
The new parameter `org_tag` is needed for both requests `/search` (since v0.9.0) as well as `/entries` (this PR).

### TODO
- [x] Add tests