### PR TITLE
ofdb-entities: Use thiserror in geo module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,6 +1449,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/ofdb-core/src/bbox.rs
+++ b/ofdb-core/src/bbox.rs
@@ -6,21 +6,21 @@ const BBOX_LNG_DEG_EXT: f64 = 0.04;
 pub fn extend_bbox(bbox: &MapBbox) -> MapBbox {
     let south_west_lat_deg = LatCoord::min()
         .to_deg()
-        .max(bbox.south_west().lat().to_deg() - BBOX_LAT_DEG_EXT);
+        .max(bbox.southwest().lat().to_deg() - BBOX_LAT_DEG_EXT);
     let north_east_lat_deg = LatCoord::max()
         .to_deg()
-        .min(bbox.north_east().lat().to_deg() + BBOX_LAT_DEG_EXT);
-    let mut south_west_lng_deg = bbox.south_west().lng().to_deg() - BBOX_LNG_DEG_EXT;
+        .min(bbox.northeast().lat().to_deg() + BBOX_LAT_DEG_EXT);
+    let mut south_west_lng_deg = bbox.southwest().lng().to_deg() - BBOX_LNG_DEG_EXT;
     if south_west_lng_deg < LngCoord::min().to_deg() {
         // wrap around
         south_west_lng_deg += LngCoord::max().to_deg() - LngCoord::min().to_deg();
     }
-    let mut north_east_lng_deg = bbox.north_east().lng().to_deg() + BBOX_LNG_DEG_EXT;
+    let mut north_east_lng_deg = bbox.northeast().lng().to_deg() + BBOX_LNG_DEG_EXT;
     if north_east_lng_deg > LngCoord::max().to_deg() {
         // wrap around
         north_east_lng_deg -= LngCoord::max().to_deg() - LngCoord::min().to_deg();
     }
-    if bbox.south_west().lng() <= bbox.north_east().lng() {
+    if bbox.southwest().lng() <= bbox.northeast().lng() {
         if south_west_lng_deg > north_east_lng_deg {
             // overflow after wrap around (boundaries switched) -> maximize
             south_west_lng_deg = LngCoord::min().to_deg();
@@ -113,9 +113,9 @@ mod tests {
         );
         let ext_bbox = extend_bbox(&bbox);
         assert!(ext_bbox.is_valid());
-        assert_eq!(ext_bbox.south_west().lat(), LatCoord::min());
-        assert_eq!(ext_bbox.north_east().lat(), LatCoord::max());
-        assert_eq!(ext_bbox.south_west().lng(), LngCoord::min());
-        assert_eq!(ext_bbox.north_east().lng(), LngCoord::max());
+        assert_eq!(ext_bbox.southwest().lat(), LatCoord::min());
+        assert_eq!(ext_bbox.northeast().lat(), LatCoord::max());
+        assert_eq!(ext_bbox.southwest().lng(), LngCoord::min());
+        assert_eq!(ext_bbox.northeast().lng(), LngCoord::max());
     }
 }

--- a/ofdb-entities/Cargo.toml
+++ b/ofdb-entities/Cargo.toml
@@ -16,6 +16,7 @@ uuid = { version = "*", features = ["v4"] }
 url = "2"
 strum = "*"
 strum_macros = "*"
+thiserror = "*"
 
 [features]
 default = []

--- a/ofdb-entities/src/geo.rs
+++ b/ofdb-entities/src/geo.rs
@@ -523,11 +523,11 @@ impl MapBbox {
         Self::new(sw, ne)
     }
 
-    pub const fn south_west(&self) -> MapPoint {
+    pub const fn southwest(&self) -> MapPoint {
         self.sw
     }
 
-    pub const fn north_east(&self) -> MapPoint {
+    pub const fn northeast(&self) -> MapPoint {
         self.ne
     }
 

--- a/src/core/usecases/create_new_place.rs
+++ b/src/core/usecases/create_new_place.rs
@@ -68,10 +68,8 @@ pub fn prepare_new_place<D: Db>(
         image_link_url,
         custom_links: custom_links_param,
     } = e;
-    let pos = match MapPoint::try_from_lat_lng_deg(lat, lng) {
-        None => return Err(ParameterError::InvalidPosition.into()),
-        Some(pos) => pos,
-    };
+    let pos =
+        MapPoint::try_from_lat_lng_deg(lat, lng).map_err(|_| ParameterError::InvalidPosition)?;
 
     let categories: Vec<_> = categories.into_iter().map(Id::from).collect();
     let old_tags = vec![];

--- a/src/core/usecases/store_event.rs
+++ b/src/core/usecases/store_event.rs
@@ -165,12 +165,15 @@ pub fn import_new_event<D: Db>(
         None
     };
 
-    //TODO: use location.is_empty()
     let pos = if let (Some(lat), Some(lng)) = (lat, lng) {
-        MapPoint::try_from_lat_lng_deg(lat, lng)
+        Some(
+            MapPoint::try_from_lat_lng_deg(lat, lng)
+                .map_err(|_| ParameterError::InvalidPosition)?,
+        )
     } else {
         None
     };
+    //TODO: use location.is_empty()
     let location = if pos.is_some() || address.is_some() {
         Some(Location {
             pos: pos.unwrap_or_default(),

--- a/src/core/usecases/tests.rs
+++ b/src/core/usecases/tests.rs
@@ -654,7 +654,7 @@ fn create_bbox_subscription() {
 
     let bbox_subscription = db.all_bbox_subscriptions().unwrap()[0].clone();
     assert_eq!(
-        bbox_subscription.bbox.north_east().lat(),
+        bbox_subscription.bbox.northeast().lat(),
         LatCoord::from_deg(88.2)
     );
 }
@@ -700,7 +700,7 @@ fn modify_bbox_subscription() {
 
     assert_eq!(bbox_subscriptions.len(), 1);
     assert_eq!(
-        bbox_subscriptions[0].clone().bbox.north_east().lat(),
+        bbox_subscriptions[0].clone().bbox.northeast().lat(),
         LatCoord::from_deg(10.0)
     );
 }

--- a/src/core/usecases/update_place.rs
+++ b/src/core/usecases/update_place.rs
@@ -128,10 +128,8 @@ pub fn prepare_updated_place<D: Db>(
         custom_links: custom_links_param,
         ..
     } = e;
-    let pos = match MapPoint::try_from_lat_lng_deg(lat, lng) {
-        None => return Err(ParameterError::InvalidPosition.into()),
-        Some(pos) => pos,
-    };
+    let pos =
+        MapPoint::try_from_lat_lng_deg(lat, lng).map_err(|_| ParameterError::InvalidPosition)?;
     let address = Address {
         street,
         zip,

--- a/src/infrastructure/db/sqlite/connection.rs
+++ b/src/infrastructure/db/sqlite/connection.rs
@@ -1745,8 +1745,8 @@ impl Db for SqliteConnection {
 
     fn create_bbox_subscription(&self, new: &BboxSubscription) -> Result<()> {
         let user_id = resolve_user_created_by_email(self, &new.user_email)?;
-        let (south_west_lat, south_west_lng) = new.bbox.south_west().to_lat_lng_deg();
-        let (north_east_lat, north_east_lng) = new.bbox.north_east().to_lat_lng_deg();
+        let (south_west_lat, south_west_lng) = new.bbox.southwest().to_lat_lng_deg();
+        let (north_east_lat, north_east_lng) = new.bbox.northeast().to_lat_lng_deg();
         let insertable = models::NewBboxSubscription {
             uid: new.id.as_ref(),
             user_id,

--- a/src/infrastructure/db/sqlite/connection.rs
+++ b/src/infrastructure/db/sqlite/connection.rs
@@ -1192,6 +1192,8 @@ impl EventGateway for SqliteConnection {
 
             let pos = if let (Some(lat), Some(lng)) = (lat, lng) {
                 MapPoint::try_from_lat_lng_deg(lat, lng)
+                    .map(Some)
+                    .unwrap_or_default()
             } else {
                 None
             };

--- a/src/infrastructure/db/sqlite/util.rs
+++ b/src/infrastructure/db/sqlite/util.rs
@@ -124,6 +124,8 @@ pub(crate) fn event_from_event_entity_and_tags(e: EventEntity, tag_rels: &[Event
     };
     let pos = if let (Some(lat), Some(lng)) = (lat, lng) {
         MapPoint::try_from_lat_lng_deg(lat, lng)
+            .map(Some)
+            .unwrap_or_default()
     } else {
         None
     };

--- a/src/infrastructure/db/tantivy/mod.rs
+++ b/src/infrastructure/db/tantivy/mod.rs
@@ -463,26 +463,26 @@ impl TantivyIndex {
             debug_assert!(!bbox.is_empty());
             let lat_query = RangeQuery::new_f64_bounds(
                 self.fields.lat,
-                Bound::Included(bbox.south_west().lat().to_deg()),
-                Bound::Included(bbox.north_east().lat().to_deg()),
+                Bound::Included(bbox.southwest().lat().to_deg()),
+                Bound::Included(bbox.northeast().lat().to_deg()),
             );
             // Latitude query: Always inclusive
             sub_queries.push((Occur::Must, Box::new(lat_query)));
             // Longitude query: Either inclusive or exclusive (wrap around)
-            if bbox.south_west().lng() <= bbox.north_east().lng() {
+            if bbox.southwest().lng() <= bbox.northeast().lng() {
                 // regular (inclusive)
                 let lng_query = RangeQuery::new_f64_bounds(
                     self.fields.lng,
-                    Bound::Included(bbox.south_west().lng().to_deg()),
-                    Bound::Included(bbox.north_east().lng().to_deg()),
+                    Bound::Included(bbox.southwest().lng().to_deg()),
+                    Bound::Included(bbox.northeast().lng().to_deg()),
                 );
                 sub_queries.push((Occur::Must, Box::new(lng_query)));
             } else {
                 // inverse (exclusive)
                 let lng_query = RangeQuery::new_f64_bounds(
                     self.fields.lng,
-                    Bound::Excluded(bbox.north_east().lng().to_deg()),
-                    Bound::Excluded(bbox.south_west().lng().to_deg()),
+                    Bound::Excluded(bbox.northeast().lng().to_deg()),
+                    Bound::Excluded(bbox.southwest().lng().to_deg()),
                 );
                 sub_queries.push((Occur::MustNot, Box::new(lng_query)));
             }
@@ -495,26 +495,26 @@ impl TantivyIndex {
             debug_assert!(!bbox.is_empty());
             let lat_query = RangeQuery::new_f64_bounds(
                 self.fields.lat,
-                Bound::Included(bbox.south_west().lat().to_deg()),
-                Bound::Included(bbox.north_east().lat().to_deg()),
+                Bound::Included(bbox.southwest().lat().to_deg()),
+                Bound::Included(bbox.northeast().lat().to_deg()),
             );
             // Latitude query: Always exclusive
             sub_queries.push((Occur::MustNot, Box::new(lat_query)));
             // Longitude query: Either exclusive or inclusive (wrap around)
-            if bbox.south_west().lng() <= bbox.north_east().lng() {
+            if bbox.southwest().lng() <= bbox.northeast().lng() {
                 // regular (exclusive)
                 let lng_query = RangeQuery::new_f64_bounds(
                     self.fields.lng,
-                    Bound::Included(bbox.south_west().lng().to_deg()),
-                    Bound::Included(bbox.north_east().lng().to_deg()),
+                    Bound::Included(bbox.southwest().lng().to_deg()),
+                    Bound::Included(bbox.northeast().lng().to_deg()),
                 );
                 sub_queries.push((Occur::MustNot, Box::new(lng_query)));
             } else {
                 // inverse (inclusive)
                 let lng_query = RangeQuery::new_f64_bounds(
                     self.fields.lng,
-                    Bound::Excluded(bbox.north_east().lng().to_deg()),
-                    Bound::Excluded(bbox.south_west().lng().to_deg()),
+                    Bound::Excluded(bbox.northeast().lng().to_deg()),
+                    Bound::Excluded(bbox.southwest().lng().to_deg()),
                 );
                 sub_queries.push((Occur::Must, Box::new(lng_query)));
             }

--- a/src/ports/cli.rs
+++ b/src/ports/cli.rs
@@ -23,7 +23,7 @@ fn update_event_locations<D: Db>(db: &mut D) -> Result<()> {
         if let Some(ref mut loc) = e.location {
             if let Some(ref addr) = loc.address {
                 if let Some((lat, lng)) = GEO_CODING_GW.resolve_address_lat_lng(addr) {
-                    if let Some(pos) = MapPoint::try_from_lat_lng_deg(lat, lng) {
+                    if let Ok(pos) = MapPoint::try_from_lat_lng_deg(lat, lng) {
                         if pos.is_valid() {
                             if let Err(err) = db.update_event(&e) {
                                 warn!("Failed to update location of event {}: {}", e.id, err);

--- a/src/ports/web/api/events/mod.rs
+++ b/src/ports/web/api/events/mod.rs
@@ -20,6 +20,8 @@ mod tests;
 fn check_and_set_address_location(e: &mut usecases::NewEvent) -> Option<MapPoint> {
     let pos = if let (Some(lat), Some(lng)) = (e.lat, e.lng) {
         MapPoint::try_from_lat_lng_deg(lat, lng)
+            .map(Some)
+            .unwrap_or_default()
     } else {
         None
     };
@@ -39,8 +41,7 @@ fn check_and_set_address_location(e: &mut usecases::NewEvent) -> Option<MapPoint
     GEO_CODING_GW
         .resolve_address_lat_lng(&addr)
         .and_then(|(lat, lng)| {
-            let pos = MapPoint::try_from_lat_lng_deg(lat, lng);
-            if pos.unwrap_or_default().is_valid() {
+            if let Ok(pos) = MapPoint::try_from_lat_lng_deg(lat, lng) {
                 log::debug!(
                     "Updating event location: ({:?}, {:?}) -> {:?}",
                     e.lat,

--- a/src/ports/web/api/mod.rs
+++ b/src/ports/web/api/mod.rs
@@ -455,10 +455,10 @@ fn get_bbox_subscriptions(
         .into_iter()
         .map(|s| json::BboxSubscription {
             id: s.id.into(),
-            south_west_lat: s.bbox.south_west().lat().to_deg(),
-            south_west_lng: s.bbox.south_west().lng().to_deg(),
-            north_east_lat: s.bbox.north_east().lat().to_deg(),
-            north_east_lng: s.bbox.north_east().lng().to_deg(),
+            south_west_lat: s.bbox.southwest().lat().to_deg(),
+            south_west_lng: s.bbox.southwest().lng().to_deg(),
+            north_east_lat: s.bbox.northeast().lat().to_deg(),
+            north_east_lng: s.bbox.northeast().lng().to_deg(),
         })
         .collect();
     Ok(Json(user_subscriptions))


### PR DESCRIPTION
First step towards better error handling and safe conversions between ofdb-boundary and ofdb-entities:

- Use `thiserror` for parsing and validating `GeoCoord`/`MapPoint`/`MapBbox` inputs
- Return `Result` instead of `Option` from `try_from()` functions

thiserror was not available when this module has been created.