### PR TITLE
Add wasm-bindgen feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ofdb-entities/Cargo.toml
+++ b/ofdb-entities/Cargo.toml
@@ -20,6 +20,7 @@ strum_macros = "*"
 [features]
 default = []
 builders = []
+wasm-bindgen = ["uuid/wasm-bindgen"]
 
 [dev-dependencies]
 rand = "*"


### PR DESCRIPTION
At the moment `ofdb-entities` cannot used in for WASM:
```shel
cargo build --target wasm32-unknown-unknown                                                                                                                                                  :(

error[E0599]: no function or associated item named `new_v4` found for struct `uuid::Uuid` in the current scope
  --> ofdb-entities/src/id.rs:10:15
   |
10 |         Uuid::new_v4().into()
   |               ^^^^^^ function or associated item not found in `uuid::Uuid`

error[E0599]: no function or associated item named `new_v4` found for struct `uuid::Uuid` in the current scope
  --> ofdb-entities/src/nonce.rs:12:20
   |
12 |         Self(Uuid::new_v4())
   |                    ^^^^^^ function or associated item not found in `uuid::Uuid`

error: aborting due to 2 previous errors
```