### PR TITLE
Prevent unauthorized editing of owned events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.9.3 (unreleased)
 
 - new(web): Set property `SameSite` to `Lax` in frontend login cookie
+- fix(api): Prevent unauthorized editing of events
 
 ## v0.9.2 (2020-09-22)
 

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -68,11 +68,15 @@ pub trait EventGateway {
     fn all_events_chronologically(&self) -> Result<Vec<Event>>;
 
     fn count_events(&self) -> Result<usize>;
-    // Delete an event, but only if tagged with at least one of the given tags
-    // Ok(Some(())) => Found and deleted
-    // Ok(None)     => No matching tags
+
+    // Delete an event, but only if tagged with at least one of the given tags.
+    // If no tags are provided the event is deleted unconditionally.
+    // Ok(true)  => Found and deleted
+    // Ok(false) => Found but no matching tags
     // TODO: Use explicit result semantics
-    fn delete_event_with_matching_tags(&self, id: &str, tags: &[&str]) -> Result<Option<()>>;
+    fn delete_event_with_matching_tags(&self, id: &str, tags: &[&str]) -> Result<bool>;
+
+    fn is_event_owned_by_any_organization(&self, id: &str) -> Result<bool>;
 }
 
 pub trait UserGateway {

--- a/src/core/usecases/store_event.rs
+++ b/src/core/usecases/store_event.rs
@@ -121,7 +121,8 @@ pub fn import_new_event<D: Db>(
                         owned_tag_count += 1;
                     }
                 }
-                if owned_tag_count == 0 {
+                if owned_tag_count == 0 && db.is_event_owned_by_any_organization(id)? {
+                    // Prevent editing of events that are owned by another organization
                     return Err(ParameterError::ModeratedTag.into());
                 }
                 let old_tags = old_event.tags;

--- a/src/core/usecases/tests.rs
+++ b/src/core/usecases/tests.rs
@@ -337,7 +337,11 @@ impl EventGateway for MockDb {
         unimplemented!();
     }
 
-    fn delete_event_with_matching_tags(&self, _id: &str, _tags: &[&str]) -> RepoResult<Option<()>> {
+    fn delete_event_with_matching_tags(&self, _id: &str, _tags: &[&str]) -> RepoResult<bool> {
+        unimplemented!();
+    }
+
+    fn is_event_owned_by_any_organization(&self, _id: &str) -> RepoResult<bool> {
         unimplemented!();
     }
 }

--- a/src/ports/web/api/events/tests/delete.rs
+++ b/src/ports/web/api/events/tests/delete.rs
@@ -121,7 +121,8 @@ fn with_api_token_by_organization_without_any_moderated_tags() {
 #[test]
 fn with_api_token_from_different_org_unauthorized() {
     let (client, db, mut search_engine, notify) = setup2();
-    let _creator_org = db.exclusive()
+    let _creator_org = db
+        .exclusive()
         .unwrap()
         .create_org(Organization {
             id: "creator".into(),
@@ -130,7 +131,8 @@ fn with_api_token_from_different_org_unauthorized() {
             api_token: "creator".into(),
         })
         .unwrap();
-    let _deleter_org = db.exclusive()
+    let _deleter_org = db
+        .exclusive()
         .unwrap()
         .create_org(Organization {
             id: "deleter".into(),

--- a/src/ports/web/api/events/tests/update.rs
+++ b/src/ports/web/api/events/tests/update.rs
@@ -286,7 +286,8 @@ fn with_api_token_created_by() {
 #[test]
 fn with_api_token_from_different_org_unauthorized() {
     let (client, db, mut search_engine, notify) = setup2();
-    let _creator_org = db.exclusive()
+    let _creator_org = db
+        .exclusive()
         .unwrap()
         .create_org(Organization {
             id: "creator".into(),
@@ -295,7 +296,8 @@ fn with_api_token_from_different_org_unauthorized() {
             api_token: "creator".into(),
         })
         .unwrap();
-    let _updater_org = db.exclusive()
+    let _updater_org = db
+        .exclusive()
         .unwrap()
         .create_org(Organization {
             id: "updater".into(),


### PR DESCRIPTION
A quick and dirty fix covered by a regression test.

Deletion was already forbidden, but the additional regression test doesn't hurt.