### PR TITLE
Search duplicates: Require less properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.5 (Unreleased)
+
+- fix(api): Only require title, description, lat, lng for /search/duplicates
+
 ## v0.10.4 (2021-08-06)
 
 - fix(api): Implement JSON errors for most cases

--- a/ofdb-boundary/src/lib.rs
+++ b/ofdb-boundary/src/lib.rs
@@ -79,9 +79,16 @@ pub struct NewPlace {
     pub homepage       : Option<String>,
     pub opening_hours  : Option<String>,
     pub founded_on     : Option<NaiveDate>,
+
+    #[serde(default = "Default::default")]
     pub categories     : Vec<String>,
+
+    #[serde(default = "Default::default")]
     pub tags           : Vec<String>,
+
+    #[serde(default = "Default::default")]
     pub license        : String,
+
     pub image_url      : Option<String>,
     pub image_link_url : Option<String>,
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -914,7 +914,6 @@ components:
         - lng
         - categories
         - tags
-        - links
     NewEntryWithLicense:
       allOf:
         - $ref: '#/components/schemas/NewEntry'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -912,8 +912,6 @@ components:
         - description
         - lat
         - lng
-        - categories
-        - tags
     NewEntryWithLicense:
       allOf:
         - $ref: '#/components/schemas/NewEntry'
@@ -921,8 +919,6 @@ components:
           properties:
             license:
               $ref: '#/components/schemas/License'
-          required:
-            - license
     NewEntryWithVersion:
       allOf:
         - $ref: '#/components/schemas/NewEntry'

--- a/src/ports/web/api/tests.rs
+++ b/src/ports/web/api/tests.rs
@@ -1976,7 +1976,7 @@ fn search_duplicates() {
     let (client, db) = setup();
     let res = client.post("/entries")
                     .header(ContentType::JSON)
-                    .body(r#"{"title":"foo","description":"bla","lat":0.0,"lng":0.0,"categories":["x"],"license":"CC0-1.0","tags":[]}"#)
+                    .body(r#"{"title":"foo","description":"bla","lat":0.0,"lng":0.0,"categories":["x"],"license":"CC0-1.0","tags":["test"]}"#)
                     .dispatch();
     assert_eq!(res.status(), Status::Ok);
     let (place, _) = db
@@ -1987,10 +1987,11 @@ fn search_duplicates() {
         .into_iter()
         .next()
         .unwrap();
-    let mut res = client.post("/search/duplicates")
-                    .header(ContentType::JSON)
-                    .body(r#"{"title":"foO","description":"bla","lat":0.0005,"lng":0.0005,"categories":["y"],"license":"CC0-1.0","tags":[]}"#)
-                    .dispatch();
+    let mut res = client
+        .post("/search/duplicates")
+        .header(ContentType::JSON)
+        .body(r#"{"title":"foO","description":"bla","lat":0.0005,"lng":0.0005}"#)
+        .dispatch();
     assert_eq!(res.status(), Status::Ok);
     test_json(&res);
     let body_str = res.body().and_then(|b| b.into_string()).unwrap();


### PR DESCRIPTION
Use default values for missing JSON properties when deserializing (resolves #363). The properties `tags` and ` categories` are always serialized even if empty for backwards compatibility!

Mandatory properties for /search/duplicates:

- title
- description
- lat
- lng