### PR TITLE
Explicitly initialize SQLite with the desired settings

### DIFF
--- a/ofdb-db-sqlite/src/lib.rs
+++ b/ofdb-db-sqlite/src/lib.rs
@@ -128,6 +128,31 @@ pub struct Connections {
     pool: SharedConnectionPool,
 }
 
+/// Configure the database engine
+///
+/// The implementation of the repositories and use cases relies on a proper
+/// configuration of the database engine like the behavior, e.g. recursive
+/// cascading deletes.
+///
+/// Some values like the text encoding can only be changed once after the
+/// database has initially been created.
+pub fn initialize_database(connection: &mut SqliteConnection) -> Fallible<()> {
+    use diesel::RunQueryDsl as _;
+    diesel::sql_query(r#"
+PRAGMA journal_mode = WAL;        -- better write-concurrency
+PRAGMA synchronous = NORMAL;      -- fsync only in critical moments, safe for journal_mode = WAL
+PRAGMA wal_autocheckpoint = 1000; -- write WAL changes back every 1000 pages (default), for an in average 1MB WAL file
+PRAGMA wal_checkpoint(TRUNCATE);  -- free some space by truncating possibly massive WAL files from the last run
+PRAGMA secure_delete = 0;         -- avoid some disk I/O
+PRAGMA automatic_index = 1;       -- detect and log missing indexes
+PRAGMA foreign_keys = 1;          -- check foreign key constraints
+PRAGMA defer_foreign_keys = 1;    -- delay enforcement of foreign key constraints until commit
+PRAGMA recursive_triggers = 1;    -- for recursive ON CASCADE DELETE actions
+PRAGMA encoding = 'UTF-8';
+"#).execute(connection)?;
+    Ok(())
+}
+
 impl Connections {
     pub fn init(url: &str, pool_size: u32) -> Fallible<Self> {
         // Establish a test connection before creating the connection pool to fail early.
@@ -143,6 +168,7 @@ impl Connections {
         let pool = ConnectionPool::builder()
             .max_size(pool_size)
             .build(manager)?;
+        initialize_database(&mut *pool.get()?)?;
         Ok(Self::new(pool))
     }
 


### PR DESCRIPTION
Remark: Cascading deletes are currently not used, but if they are used the settings make sense.