### PR TITLE
Fix Dockerfile and add CI check

### DIFF
--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow
 
-name: Create and publish a Docker image
+name: Build a Docker image
 
 on:
   push:
@@ -12,7 +12,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push-image:
+  build-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow
+
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -16,23 +16,22 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: false

--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -2,7 +2,6 @@
 
 name: Create and publish a Docker image
 
-# Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
     branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ARG BUILD_BIN=${PROJECT_NAME}
 # 1st Build Stage
 # The tag of the base image must match the version in the file rust-toolchain!
 # Available images can be found at https://hub.docker.com/r/clux/muslrust/tags/
-FROM clux/muslrust:stable AS build
+FROM docker.io/clux/muslrust:stable AS build
 
 # Import global ARGs
 ARG WORKDIR_ROOT
@@ -57,6 +57,8 @@ RUN USER=root cargo new --lib ofdb-application \
     && \
     USER=root cargo new --lib ofdb-entities \
     && \
+    USER=root cargo new --lib ofdb-frontend-api \
+    && \
     USER=root cargo new --lib ofdb-gateways \
     && \
     USER=root cargo new --lib ofdb-webserver
@@ -85,6 +87,9 @@ COPY [ \
     "ofdb-entities/Cargo.toml", \
     "./ofdb-entities/" ]
 COPY [ \
+    "ofdb-frontend-api/Cargo.toml", \
+    "./ofdb-frontend-api/" ]
+COPY [ \
     "ofdb-gateways/Cargo.toml", \
     "./ofdb-gateways/" ]
 COPY [ \
@@ -109,6 +114,8 @@ RUN cargo build --${BUILD_MODE} --target ${BUILD_TARGET} --workspace \
     rm -f ./target/${BUILD_TARGET}/${BUILD_MODE}/deps/ofdb_db_tantivy-* \
     && \
     rm -f ./target/${BUILD_TARGET}/${BUILD_MODE}/deps/ofdb_entities-* \
+    && \
+    rm -f ./target/${BUILD_TARGET}/${BUILD_MODE}/deps/ofdb_frontend_api-* \
     && \
     rm -f ./target/${BUILD_TARGET}/${BUILD_MODE}/deps/ofdb_gateways-* \
     && \
@@ -137,9 +144,6 @@ COPY [ \
     "openapi.yaml", \
     "./" ]
 COPY [ \
-    "migrations", \
-    "./migrations/" ]
-COPY [ \
     "ofdb-app-clearance", \
     "./ofdb-app-clearance/" ]
 COPY [ \
@@ -155,14 +159,20 @@ COPY [ \
     "ofdb-db-sqlite/src", \
     "./ofdb-db-sqlite/src/" ]
 COPY [ \
+    "ofdb-db-sqlite/migrations", \
+    "./ofdb-db-sqlite/migrations/" ]
+COPY [ \
     "ofdb-db-tantivy/src", \
     "./ofdb-db-tantivy/src/" ]
 COPY [ \
     "ofdb-entities/src", \
     "./ofdb-entities/src/" ]
 COPY [ \
-    "ofdb-gateways/src", \
-    "./ofdb-gateways/src/" ]
+    "ofdb-frontend-api/src", \
+    "./ofdb-frontend-api/src/" ]
+COPY [ \
+    "ofdb-gateways", \
+    "./ofdb-gateways/" ]
 COPY [ \
     "ofdb-webserver/build.rs", \
     "./ofdb-webserver/build.rs" ]
@@ -185,6 +195,8 @@ RUN cargo check --${BUILD_MODE} --target ${BUILD_TARGET} --package ofdb-applicat
     cargo check --${BUILD_MODE} --target ${BUILD_TARGET} --package ofdb-db-tantivy \
     && \
     cargo check --${BUILD_MODE} --target ${BUILD_TARGET} --package ofdb-entities \
+    && \
+    cargo check --${BUILD_MODE} --target ${BUILD_TARGET} --package ofdb-frontend-api \
     && \
     cargo check --${BUILD_MODE} --target ${BUILD_TARGET} --package ofdb-gateways \
     && \


### PR DESCRIPTION
1. Added resources that were missing the for docker context.
2. Added explicit dockerhub reference `docker.io` in the Dockerfile to allow using it with docker-alternatives like podman.
3. Added github workflow to build docker image (pushing disabled).

This should fix #517 .

To try it, run
```sh
docker build -t openfairdb:latest .
docker run -p 8081:8080 -e ROCKET_SECRET_KEY="hPRYyVRiMyxpw5sBB1XeCMN1kFsDCqKvBi2QJxBVHQk=" -e RUST_LOG="trace" openfairdb
```

In you wanted, you could publish docker images with your release e.g. to ghcr.io also.